### PR TITLE
Use Sforce-Call-Options header for client attribution

### DIFF
--- a/src/main/java/com/salesforce/data360/mcp/config/RestClientConfig.java
+++ b/src/main/java/com/salesforce/data360/mcp/config/RestClientConfig.java
@@ -21,7 +21,6 @@ import com.salesforce.data360.mcp.client.Data360Client;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -44,8 +43,10 @@ public class RestClientConfig {
         );
     }
 
+    static final String SFORCE_CALL_OPTIONS = "Sforce-Call-Options";
+
     static RestClient.Builder restClientBuilder(String serverName, String serverVersion) {
         return RestClient.builder()
-            .defaultHeader(HttpHeaders.USER_AGENT, serverName + "/" + serverVersion);
+            .defaultHeader(SFORCE_CALL_OPTIONS, "client=" + serverName + "/" + serverVersion);
     }
 }

--- a/src/test/java/com/salesforce/data360/mcp/config/RestClientConfigTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/config/RestClientConfigTest.java
@@ -17,7 +17,6 @@
 package com.salesforce.data360.mcp.config;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
@@ -29,7 +28,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 public class RestClientConfigTest {
 
     @Test
-    public void restClientSendsUserAgentHeader() {
+    public void restClientSendsSforceCallOptionsHeader() {
         RestClient.Builder builder = RestClientConfig.restClientBuilder(
             "data360-mcp-server-oss", "1.0.0"
         );
@@ -37,7 +36,7 @@ public class RestClientConfigTest {
         RestClient client = builder.build();
 
         server.expect(requestTo("https://example.test/ping"))
-            .andExpect(header(HttpHeaders.USER_AGENT, "data360-mcp-server-oss/1.0.0"))
+            .andExpect(header(RestClientConfig.SFORCE_CALL_OPTIONS, "client=data360-mcp-server-oss/1.0.0"))
             .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
         client.get().uri("https://example.test/ping").retrieve().toBodilessEntity();


### PR DESCRIPTION
## Summary
- Replace `User-Agent` header with `Sforce-Call-Options: client=<name>/<version>` for Salesforce client attribution
- Update `RestClientConfigTest` to verify the new header

## Test plan
- [x] `mvn compile` passes
- [x] All 500 tests pass (`mvn test` — 0 failures, 0 errors)