### PR TITLE
Add one-command installer for MCP client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,52 @@ Under the hood, 187 operations are organized into 21 tool families:
 | Eventing | 2 | Single + batch event publish |
 | GDPR | 3 | Data subject read / delete requests |
 
-## Requirements
+## Quick start (one command)
+
+The installer checks for Java 17+ and Maven (installs them if missing),
+clones the repo, builds the server JAR, prompts for your Salesforce
+credentials, and configures your MCP client (Claude Desktop, Claude Code,
+or Cursor):
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/forcedotcom/d360-mcp-server/refs/heads/main/install.sh | bash
+```
+
+That's it. The script handles everything — including installing Java, Maven,
+and Git if you don't have them.
+
+If you already cloned the repo and want to build the current checkout, run:
+
+```bash
+./install.sh
+```
+
+### Windows (PowerShell)
+
+Install [Python 3.9+](https://www.python.org/downloads/windows/) first (the
+installer uses only the Python standard library). Then:
+
+```powershell
+irm https://raw.githubusercontent.com/forcedotcom/d360-mcp-server/refs/heads/main/install.py -OutFile install.py
+python install.py
+```
+
+The Python installer auto-installs Git, Java 17, and Maven via `winget`
+(falls back to Chocolatey if present). You may see a UAC prompt.
+
+### Cross-platform alternative
+
+A Python installer is also available on macOS and Linux:
+
+```bash
+python3 install.py
+```
+
+## Requirements (manual setup)
+
+If you prefer to set things up yourself:
 
 - Java 17+
 - Maven 3.9+
@@ -242,6 +287,27 @@ mvn test
 ```
 
 The test suite covers core tool dispatch, services, and request/response behavior.
+
+## Uninstall
+
+If you used the installer, use its uninstall command to remove the installed
+JAR and the `"data360"` entries it added to supported MCP clients:
+
+```bash
+./install.sh uninstall
+```
+
+On Windows, run:
+
+```powershell
+python install.py uninstall
+```
+
+Manual cleanup is also possible: remove `~/.data360-mcp-server`, then remove
+the `"data360"` entry from your MCP client config file:
+- Claude Desktop: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux)
+- Claude Code: `~/.claude.json`
+- Cursor: `~/.cursor/mcp.json`
 
 ## Contributing
 

--- a/install.py
+++ b/install.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-platform installer for the Data 360 MCP Server.
+#
+# Works on macOS, Linux, and Windows. Uses the Python standard library only.
+#
+# Usage:
+#   python3 install.py                 # install / upgrade
+#   ./install.py uninstall             # remove JAR and data360 entry from MCP configs
+#   python3 install.py --help
+#   python3 install.py --version
+#
+# Windows one-liner (PowerShell):
+#   irm https://raw.githubusercontent.com/forcedotcom/d360-mcp-server/refs/heads/main/install.py -OutFile install.py; python install.py
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+INSTALLER_VERSION = "1.1.0"
+INSTALL_DIR = Path.home() / ".data360-mcp-server"
+REPO_URL = "https://github.com/forcedotcom/d360-mcp-server"
+REPO_BRANCH = "main"
+DEFAULT_API_VERSION = "66.0"
+
+MCP_CONFIG_FILE = INSTALL_DIR / ".mcp_config.json"
+
+# Set by build_jar()
+JAR_NAME = ""
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+
+def _colors_enabled() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return True
+
+if _colors_enabled():
+    # On Windows 10+, enable VT processing so ANSI codes render in cmd/PowerShell.
+    if sys.platform == "win32":
+        os.system("")
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    BLUE = "\033[0;34m"
+    BOLD = "\033[1m"
+    NC = "\033[0m"
+else:
+    RED = GREEN = YELLOW = BLUE = BOLD = NC = ""
+
+
+def info(msg: str) -> None:
+    print(f"{BLUE}[info]{NC}  {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"{GREEN}[ok]{NC}    {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"{YELLOW}[warn]{NC}  {msg}")
+
+
+def fail(msg: str) -> None:
+    print(f"{RED}[error]{NC} {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ── Prompts ──────────────────────────────────────────────────────────────────
+
+def prompt(text: str) -> str:
+    try:
+        return input(text)
+    except EOFError:
+        return ""
+
+
+def prompt_secret(text: str) -> str:
+    if not sys.stdin.isatty():
+        return prompt(text)
+    try:
+        return getpass.getpass(text)
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return ""
+
+
+# ── Retry helper ─────────────────────────────────────────────────────────────
+
+def retry(fn, *, max_attempts: int = 3, initial_delay: int = 2):
+    delay = initial_delay
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn()
+        except subprocess.CalledProcessError:
+            if attempt >= max_attempts:
+                raise
+            warn(f"Command failed (attempt {attempt}/{max_attempts}), retrying in {delay}s...")
+            time.sleep(delay)
+            delay *= 2
+
+
+# ── OS detection ─────────────────────────────────────────────────────────────
+
+def detect_os() -> str:
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "win32":
+        return "windows"
+    fail(f"Unsupported OS: {sys.platform}. This installer supports macOS, Linux, and Windows.")
+
+
+OS_TYPE = detect_os()
+
+
+# ── Subprocess helpers ───────────────────────────────────────────────────────
+
+def run(cmd, *, check: bool = True, capture: bool = False, stdin_null: bool = True, **kwargs):
+    """Run a subprocess. Uses a list — never shell=True — to avoid quoting issues
+    with paths that contain spaces on Windows."""
+    stdin = subprocess.DEVNULL if stdin_null else None
+    if capture:
+        return subprocess.run(cmd, check=check, stdin=stdin,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True, **kwargs)
+    return subprocess.run(cmd, check=check, stdin=stdin, **kwargs)
+
+
+def which(binary: str) -> str | None:
+    """shutil.which with Windows' PATHEXT handled automatically (finds .cmd/.exe)."""
+    return shutil.which(binary)
+
+
+# ── Homebrew (macOS) ─────────────────────────────────────────────────────────
+
+def ensure_homebrew() -> None:
+    if OS_TYPE != "macos":
+        return
+    if which("brew"):
+        return
+    info("Homebrew not found. Installing...")
+    installer_url = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+    installer_path: Path | None = None
+    try:
+        with urllib.request.urlopen(installer_url) as response:
+            script = response.read()
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".sh") as tmp:
+            tmp.write(script)
+            installer_path = Path(tmp.name)
+        run(["/bin/bash", str(installer_path)])
+    finally:
+        if installer_path and installer_path.exists():
+            installer_path.unlink()
+    for candidate in ("/opt/homebrew/bin/brew", "/usr/local/bin/brew"):
+        if Path(candidate).is_file():
+            # Prepend brew's bin to PATH for the rest of this process
+            brew_prefix = str(Path(candidate).parent)
+            os.environ["PATH"] = brew_prefix + os.pathsep + os.environ.get("PATH", "")
+            break
+    ok("Homebrew installed")
+
+
+# ── Package-manager dispatch ─────────────────────────────────────────────────
+
+def install_package(mac_pkg: str, apt_pkg: str, yum_pkg: str, winget_id: str | None) -> None:
+    """Install a package using the native package manager for OS_TYPE."""
+    if OS_TYPE == "macos":
+        ensure_homebrew()
+        run(["brew", "install", mac_pkg])
+        return
+
+    if OS_TYPE == "linux":
+        if which("apt-get"):
+            retry(lambda: run(["sudo", "apt-get", "update", "-qq"]))
+            run(["sudo", "apt-get", "install", "-y", "-qq", apt_pkg])
+            return
+        if which("yum"):
+            run(["sudo", "yum", "install", "-y", "-q", yum_pkg])
+            return
+        fail(f"Cannot auto-install {apt_pkg}. Please install it manually and re-run.")
+
+    if OS_TYPE == "windows":
+        if winget_id and which("winget"):
+            run(["winget", "install", "--id", winget_id, "-e", "--silent",
+                 "--accept-package-agreements", "--accept-source-agreements"])
+            return
+        if which("choco"):
+            run(["choco", "install", mac_pkg, "-y"])
+            return
+        fail(f"Cannot auto-install {winget_id or mac_pkg}. "
+             "Install winget (App Installer from Microsoft Store) or Chocolatey, then re-run.")
+
+
+# ── Git ──────────────────────────────────────────────────────────────────────
+
+def check_git() -> None:
+    if which("git"):
+        return
+    info("Git not found. Installing...")
+    install_package("git", "git", "git", "Git.Git")
+    # Fresh winget installs don't show up on PATH until a new shell; warn and bail.
+    if not which("git"):
+        fail("Git installed but not on PATH. Open a new terminal and re-run this installer.")
+    ok("Git installed")
+
+
+# ── Java 17+ ────────────────────────────────────────────────────────────────
+
+def java_major_version() -> int:
+    """Parse major version from `java -version` output. Handles modern ('17.0.5')
+    and legacy ('1.8.0_xxx') formats. Returns 0 if unknown."""
+    try:
+        result = subprocess.run(["java", "-version"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return 0
+    # `java -version` prints to stderr
+    output = (result.stderr or "") + (result.stdout or "")
+    match = re.search(r'version "([^"]+)"', output)
+    if not match:
+        return 0
+    raw = match.group(1)
+    parts = raw.split(".")
+    try:
+        major = int(parts[0])
+    except ValueError:
+        return 0
+    if major == 1 and len(parts) > 1:
+        try:
+            return int(parts[1])
+        except ValueError:
+            return 0
+    return major
+
+
+def check_java() -> None:
+    info("Checking for Java 17+...")
+    if which("java"):
+        version = java_major_version()
+        if version >= 17:
+            ok(f"Java {version} found")
+            return
+        warn(f"Java {version} found, but 17+ is required")
+    else:
+        warn("Java not found")
+
+    info("Installing Java 17...")
+    if OS_TYPE == "macos":
+        ensure_homebrew()
+        run(["brew", "install", "openjdk@17"])
+        brew_prefix = subprocess.run(["brew", "--prefix"], capture_output=True, text=True,
+                                     check=True).stdout.strip()
+        bin_dir = Path(brew_prefix) / "opt" / "openjdk@17" / "bin"
+        if bin_dir.is_dir():
+            os.environ["PATH"] = str(bin_dir) + os.pathsep + os.environ.get("PATH", "")
+    elif OS_TYPE == "linux":
+        install_package("openjdk@17", "openjdk-17-jdk", "java-17-openjdk-devel", None)
+    else:  # windows
+        install_package("openjdk17", "openjdk-17-jdk", "java-17-openjdk-devel",
+                        "EclipseAdoptium.Temurin.17.JDK")
+        if not which("java"):
+            fail("Java installed but not on PATH. Open a new terminal and re-run this installer.")
+    ok("Java 17 installed")
+
+
+# ── Maven ────────────────────────────────────────────────────────────────────
+
+def check_maven() -> None:
+    info("Checking for Maven...")
+    if which("mvn"):
+        result = subprocess.run(["mvn", "-v"], capture_output=True, text=True)
+        match = re.search(r"Apache Maven (\S+)", (result.stdout or "") + (result.stderr or ""))
+        version = match.group(1) if match else "unknown"
+        ok(f"Maven found ({version})")
+        return
+    info("Installing Maven...")
+    install_package("maven", "maven", "maven", "Apache.Maven")
+    if not which("mvn"):
+        fail("Maven installed but not on PATH. Open a new terminal and re-run this installer.")
+    ok("Maven installed")
+
+
+# ── Build the JAR ───────────────────────────────────────────────────────────
+
+def _rmtree_force(path: Path) -> None:
+    """shutil.rmtree that copes with Windows read-only files (git pack indexes)."""
+    def onerror(func, target, exc_info):
+        try:
+            os.chmod(target, stat.S_IWRITE)
+            func(target)
+        except Exception:
+            pass
+    shutil.rmtree(path, onerror=onerror)
+
+
+def _find_built_jar(build_dir: Path) -> Path | None:
+    target = build_dir / "target"
+    if not target.is_dir():
+        return None
+    for candidate in sorted(target.glob("data360-mcp-server-*.jar")):
+        if candidate.name.endswith(".original"):
+            continue
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def build_jar() -> None:
+    global JAR_NAME
+
+    INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(INSTALL_DIR, 0o700)
+    except OSError:
+        pass  # Windows: chmod is a no-op for dirs; user profile ACLs still apply
+
+    cloned_tmp: Path | None = None
+    pom = Path("pom.xml")
+    if pom.is_file() and "data360-mcp-server" in pom.read_text(errors="ignore"):
+        info("Building from local repo...")
+        build_dir = Path(".")
+    else:
+        check_git()
+        cloned_tmp = Path(tempfile.mkdtemp(prefix="d360-mcp-"))
+        clone_target = cloned_tmp / "d360-mcp-server"
+        info("Cloning repo...")
+        try:
+            run(["git", "clone", "--depth", "1", "--branch", REPO_BRANCH,
+                 REPO_URL, str(clone_target)])
+        except subprocess.CalledProcessError:
+            fail(
+                f"Failed to clone {REPO_URL}.\n"
+                "    Possible causes:\n"
+                "      • GitHub credentials not cached — try: gh auth login\n"
+                "      • Repository access not granted — check github.com/forcedotcom/d360-mcp-server\n"
+                "      • Network connectivity issue\n"
+                "    Fix the above and re-run."
+            )
+        build_dir = clone_target
+
+    info("Building JAR (this may take a minute on first run)...")
+    build_log = INSTALL_DIR / "build.log"
+    mvn_cmd = "mvn.cmd" if OS_TYPE == "windows" and which("mvn.cmd") else "mvn"
+    with open(build_log, "w") as log:
+        result = subprocess.run(
+            [mvn_cmd, "clean", "package", "-DskipTests"],
+            cwd=str(build_dir), stdin=subprocess.DEVNULL,
+            stdout=log, stderr=subprocess.STDOUT,
+        )
+    if result.returncode != 0:
+        print("\n--- Last 40 lines of build log ---")
+        tail = build_log.read_text(errors="ignore").splitlines()[-40:]
+        print("\n".join(tail))
+        print()
+        fail(f"Maven build failed. Full log: {build_log}")
+
+    jar = _find_built_jar(build_dir)
+    if not jar:
+        fail(f"Build succeeded but no JAR found in {build_dir}/target/")
+
+    JAR_NAME = jar.name
+    dest = INSTALL_DIR / JAR_NAME
+    shutil.copy2(jar, dest)
+    try:
+        os.chmod(dest, 0o644)
+    except OSError:
+        pass
+
+    if cloned_tmp and cloned_tmp.exists():
+        _rmtree_force(cloned_tmp)
+
+    ok(f"JAR installed to {dest}")
+
+
+# ── Credential reuse ────────────────────────────────────────────────────────
+
+# Populated by collect_credentials() / load_existing_credentials()
+CREDS: dict[str, str] = {}
+
+
+def load_existing_credentials() -> bool:
+    if not MCP_CONFIG_FILE.is_file():
+        return False
+    try:
+        with open(MCP_CONFIG_FILE) as f:
+            cfg = json.load(f)
+        env = cfg["mcpServers"]["data360"]["env"]
+    except (OSError, ValueError, KeyError):
+        return False
+    CREDS["AUTH_FLOW"] = env.get("DATA360_AUTH_FLOW", "access_token")
+    for key in ("DATA360_INSTANCE_URL", "DATA360_ACCESS_TOKEN",
+                "DATA360_CLIENT_ID", "DATA360_CLIENT_SECRET",
+                "DATA360_LOGIN_URL", "DATA360_API_VERSION"):
+        if key in env:
+            CREDS[key] = env[key]
+    return True
+
+
+# ── Credentials ─────────────────────────────────────────────────────────────
+
+def validate_instance_url(url: str) -> str:
+    url = url.rstrip("/")
+    if not re.match(r"^https://", url):
+        fail(f"Instance URL must start with https:// (got: '{url}')")
+    after_scheme = url.split("://", 1)[1]
+    if "/" in after_scheme:
+        fail(f"Instance URL should be host-only, with no path (got: '{url}')")
+    return url
+
+
+def collect_credentials() -> None:
+    if load_existing_credentials():
+        print()
+        print(f"{BOLD}Existing credentials detected{NC} for flow '{CREDS['AUTH_FLOW']}'.")
+        choice = prompt("Reuse them? [Y/n]: ").strip()
+        if choice in ("", "Y", "y", "Yes", "yes"):
+            ok("Reusing stored credentials")
+            return
+        CREDS.clear()
+
+    print()
+    print(f"{BOLD}Salesforce Data 360 Credentials{NC}")
+    print("Choose an auth method:")
+    print("  1) Access token  — quick setup, tokens expire")
+    print("  2) Client credentials  — auto-refreshing, recommended")
+    print()
+    auth_choice = prompt("Choose [1/2]: ").strip()
+
+    if auth_choice == "1":
+        CREDS["AUTH_FLOW"] = "access_token"
+        raw_url = prompt("DATA360_INSTANCE_URL (e.g. https://your-org.my.salesforce.com): ").strip()
+        if not raw_url:
+            fail("Instance URL is required")
+        CREDS["DATA360_INSTANCE_URL"] = validate_instance_url(raw_url)
+        token = prompt_secret("DATA360_ACCESS_TOKEN (hidden): ").strip()
+        if not token:
+            fail("Access token is required")
+        CREDS["DATA360_ACCESS_TOKEN"] = token
+
+    elif auth_choice == "2":
+        CREDS["AUTH_FLOW"] = "client_credentials"
+        client_id = prompt("DATA360_CLIENT_ID: ").strip()
+        if not client_id:
+            fail("Client ID is required")
+        CREDS["DATA360_CLIENT_ID"] = client_id
+        secret = prompt_secret("DATA360_CLIENT_SECRET (hidden): ").strip()
+        if not secret:
+            fail("Client secret is required")
+        CREDS["DATA360_CLIENT_SECRET"] = secret
+        default_login = "https://login.salesforce.com"
+        login = prompt(f"DATA360_LOGIN_URL [{default_login}]: ").strip()
+        CREDS["DATA360_LOGIN_URL"] = login or default_login
+
+    else:
+        fail("Invalid choice")
+
+    api_version = prompt(f"DATA360_API_VERSION [{DEFAULT_API_VERSION}]: ").strip()
+    CREDS["DATA360_API_VERSION"] = api_version or DEFAULT_API_VERSION
+
+
+# ── Build MCP server config ─────────────────────────────────────────────────
+
+def _write_json_secure(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        # Windows: os.chmod only toggles readonly. The file lives in the user
+        # profile, which already restricts access to other users via ACL.
+        pass
+
+
+def build_mcp_config() -> None:
+    jar_path = str(INSTALL_DIR / JAR_NAME)
+    env = {"DATA360_AUTH_FLOW": CREDS["AUTH_FLOW"]}
+    if CREDS["AUTH_FLOW"] == "access_token":
+        env["DATA360_INSTANCE_URL"] = CREDS["DATA360_INSTANCE_URL"]
+        env["DATA360_ACCESS_TOKEN"] = CREDS["DATA360_ACCESS_TOKEN"]
+    else:
+        env["DATA360_CLIENT_ID"] = CREDS["DATA360_CLIENT_ID"]
+        env["DATA360_CLIENT_SECRET"] = CREDS["DATA360_CLIENT_SECRET"]
+        env["DATA360_LOGIN_URL"] = CREDS["DATA360_LOGIN_URL"]
+    env["DATA360_API_VERSION"] = CREDS["DATA360_API_VERSION"]
+
+    cfg = {"mcpServers": {"data360": {
+        "command": "java", "args": ["-jar", jar_path], "env": env
+    }}}
+    _write_json_secure(MCP_CONFIG_FILE, cfg)
+    ok("MCP config generated")
+
+
+# ── Merge into client configs ───────────────────────────────────────────────
+
+def merge_mcp_config(config_file: Path) -> None:
+    """Atomically merge the data360 entry into a JSON config file."""
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(MCP_CONFIG_FILE) as f:
+        new_cfg = json.load(f)
+    new_server = new_cfg["mcpServers"]["data360"]
+
+    if config_file.is_file():
+        backup = config_file.with_suffix(config_file.suffix + ".bak")
+        if not backup.exists():
+            shutil.copy2(config_file, backup)
+        with open(config_file) as f:
+            existing = json.load(f)
+        existing.setdefault("mcpServers", {})["data360"] = new_server
+        tmp = config_file.with_name(f"{config_file.name}.tmp.{os.getpid()}")
+        with open(tmp, "w") as f:
+            json.dump(existing, f, indent=2)
+            f.write("\n")
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp, config_file)
+        ok(f"  Updated data360 in {config_file} (backup: {backup})")
+    else:
+        shutil.copy2(MCP_CONFIG_FILE, config_file)
+        try:
+            os.chmod(config_file, 0o600)
+        except OSError:
+            pass
+        ok(f"  Created {config_file}")
+
+
+# ── Client presence detection ───────────────────────────────────────────────
+
+def claude_desktop_config_path() -> Path:
+    if OS_TYPE == "macos":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if OS_TYPE == "windows":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "Claude" / "claude_desktop_config.json"
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def client_present_claude_desktop() -> bool:
+    if OS_TYPE == "macos":
+        return (Path.home() / "Library" / "Application Support" / "Claude").is_dir() or \
+               Path("/Applications/Claude.app").is_dir()
+    if OS_TYPE == "windows":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        local = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return (Path(appdata) / "Claude").is_dir() or (Path(local) / "AnthropicClaude").is_dir()
+    return (Path.home() / ".config" / "Claude").is_dir()
+
+
+def client_present_claude_code() -> bool:
+    return bool(which("claude")) or (Path.home() / ".claude.json").is_file()
+
+
+def cursor_config_path() -> Path:
+    return Path.home() / ".cursor" / "mcp.json"
+
+
+def client_present_cursor() -> bool:
+    if (Path.home() / ".cursor").is_dir():
+        return True
+    if OS_TYPE == "macos" and Path("/Applications/Cursor.app").is_dir():
+        return True
+    return bool(which("cursor"))
+
+
+# ── Configure clients ───────────────────────────────────────────────────────
+
+def configure_claude_desktop() -> None:
+    info("Configuring Claude Desktop...")
+    merge_mcp_config(claude_desktop_config_path())
+
+
+def configure_claude_code() -> None:
+    info("Configuring Claude Code...")
+    if which("claude"):
+        with open(MCP_CONFIG_FILE) as f:
+            cfg = json.load(f)
+        server_json = json.dumps(cfg["mcpServers"]["data360"])
+        # Keep idempotent: best-effort remove before add
+        subprocess.run(["claude", "mcp", "remove", "data360"],
+                       stdin=subprocess.DEVNULL,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        add = subprocess.run(["claude", "mcp", "add-json", "--scope", "user",
+                              "data360", server_json],
+                             stdin=subprocess.DEVNULL)
+        if add.returncode == 0:
+            ok("  Registered data360 via 'claude mcp add-json --scope user'")
+            return
+        warn("'claude mcp add-json' failed — falling back to direct merge")
+    merge_mcp_config(Path.home() / ".claude.json")
+
+
+def configure_cursor() -> None:
+    info("Configuring Cursor...")
+    merge_mcp_config(cursor_config_path())
+
+
+def configure_clients() -> None:
+    print()
+    print(f"{BOLD}Configure MCP Clients{NC}")
+
+    cd_note = "" if client_present_claude_desktop() else "  (not detected)"
+    cc_note = "" if client_present_claude_code() else "  (not detected)"
+    cu_note = "" if client_present_cursor() else "  (not detected)"
+
+    print("Which clients would you like to configure?")
+    print(f"  1) Claude Desktop{cd_note}")
+    print(f"  2) Claude Code{cc_note}")
+    print(f"  3) Cursor{cu_note}")
+    print("  4) All detected")
+    print("  5) None — I'll configure manually")
+    print()
+    choice = prompt("Choose [1/2/3/4/5]: ").strip()
+
+    if choice == "1":
+        configure_claude_desktop()
+    elif choice == "2":
+        configure_claude_code()
+    elif choice == "3":
+        configure_cursor()
+    elif choice == "4":
+        if client_present_claude_desktop():
+            configure_claude_desktop()
+        else:
+            warn("Skipping Claude Desktop (not detected)")
+        if client_present_claude_code():
+            configure_claude_code()
+        else:
+            warn("Skipping Claude Code (not detected)")
+        if client_present_cursor():
+            configure_cursor()
+        else:
+            warn("Skipping Cursor (not detected)")
+    elif choice == "5":
+        print()
+        print(f"{BOLD}Manual configuration:{NC}")
+        print("Your MCP server config was saved (with secrets) to:")
+        print(f"  {BOLD}{MCP_CONFIG_FILE}{NC}")
+        print()
+        print("Copy its contents into your MCP client's configuration.")
+        print("(File permissions are 600 — do not print it in shared terminals.)")
+    else:
+        fail("Invalid choice")
+
+
+# ── Uninstall ───────────────────────────────────────────────────────────────
+
+def remove_from_config(config_file: Path) -> None:
+    if not config_file.is_file():
+        return
+    try:
+        with open(config_file) as f:
+            cfg = json.load(f)
+    except (OSError, ValueError):
+        return
+    servers = cfg.get("mcpServers", {})
+    if "data360" not in servers:
+        info(f"  No data360 entry in {config_file}")
+        return
+    del servers["data360"]
+    tmp = config_file.with_name(f"{config_file.name}.tmp.{os.getpid()}")
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, config_file)
+    ok(f"  Removed data360 from {config_file}")
+
+
+def uninstall() -> None:
+    print()
+    print(f"{BOLD}Uninstalling Data 360 MCP Server{NC}")
+    print()
+
+    if which("claude"):
+        info("Removing from Claude Code (via CLI)...")
+        result = subprocess.run(["claude", "mcp", "remove", "data360"],
+                                stdin=subprocess.DEVNULL,
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if result.returncode == 0:
+            ok("  Removed via 'claude mcp remove'")
+
+    remove_from_config(claude_desktop_config_path())
+    remove_from_config(Path.home() / ".claude.json")
+    remove_from_config(cursor_config_path())
+
+    if INSTALL_DIR.is_dir():
+        info(f"Removing {INSTALL_DIR}...")
+        _rmtree_force(INSTALL_DIR)
+        ok("Removed install directory")
+
+    print()
+    print(f"{GREEN}Uninstall complete.{NC}")
+    print("Config backups (if any) remain at <config>.bak — remove them manually if desired.")
+    print()
+
+
+# ── Main install flow ───────────────────────────────────────────────────────
+
+def main_install() -> None:
+    print()
+    print(f"{BOLD}Data 360 MCP Server Installer{NC} (v{INSTALLER_VERSION})")
+    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print()
+
+    check_java()
+    check_maven()
+    build_jar()
+    collect_credentials()
+    build_mcp_config()
+    configure_clients()
+
+    print()
+    print(f"{GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{NC}")
+    print(f"{GREEN}{BOLD}Installation complete!{NC}")
+    print(f"{GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{NC}")
+    print()
+    print(f"  JAR location:  {INSTALL_DIR / JAR_NAME}")
+    print()
+    print("  To test manually:")
+    print(f"    java -jar {INSTALL_DIR / JAR_NAME}")
+    print()
+    print("  To update later:")
+    print("    Re-run this script — it will rebuild from the current source")
+    print("    and reuse your stored credentials.")
+    print()
+    print(f"  To uninstall:")
+    print(f"    ./install.py uninstall" if OS_TYPE != "windows"
+          else "    python install.py uninstall")
+    print()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="install.py",
+        description=f"Data 360 MCP Server installer v{INSTALLER_VERSION}",
+        add_help=True,
+    )
+    parser.add_argument("-V", "--version", action="version",
+                        version=f"install.py v{INSTALLER_VERSION}")
+    parser.add_argument("action", nargs="?", default="install",
+                        choices=["install", "uninstall"],
+                        help="install (default) or uninstall")
+    args = parser.parse_args()
+
+    if args.action == "uninstall":
+        uninstall()
+    else:
+        main_install()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print()
+        sys.exit(130)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,723 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-command installer for the Data 360 MCP Server.
+#
+# Usage (remote — clones, builds, and configures everything):
+#   curl -fsSL https://raw.githubusercontent.com/forcedotcom/d360-mcp-server/refs/heads/main/install.sh | bash
+#
+# Usage (local — run from inside a cloned repo):
+#   ./install.sh                  # install / upgrade
+#   ./install.sh uninstall        # remove JAR and data360 entry from MCP configs
+#   ./install.sh --help           # show help
+#   ./install.sh --version        # show installer version
+#
+# What it does:
+#   1. Checks for / installs Java 17+, Maven, Git, and python3
+#   2. Clones the repo (if not already in it) and builds the fat JAR
+#   3. Prompts for Salesforce credentials (secrets are masked)
+#   4. Configures your MCP client (Claude Desktop, Claude Code, Cursor) atomically
+
+set -euo pipefail
+
+# Read prompts from the controlling terminal when available so `curl | bash`
+# installs can still ask for credentials after stdin has carried the script.
+if ! { exec 3</dev/tty; } 2>/dev/null; then
+    exec 3<&0
+fi
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+INSTALLER_VERSION="1.1.0"
+INSTALL_DIR="${HOME}/.data360-mcp-server"
+REPO_URL="https://github.com/forcedotcom/d360-mcp-server"
+REPO_BRANCH="main"
+DEFAULT_API_VERSION="66.0"
+
+# Populated by build_jar
+JAR_NAME=""
+# Well-known path — set early so load_existing_credentials can find it on re-runs,
+# before build_mcp_config has had a chance to run.
+MCP_CONFIG_FILE="${INSTALL_DIR}/.mcp_config.json"
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { printf "${BLUE}[info]${NC}  %s\n" "$1"; }
+ok()    { printf "${GREEN}[ok]${NC}    %s\n" "$1"; }
+warn()  { printf "${YELLOW}[warn]${NC}  %s\n" "$1"; }
+fail()  { printf "${RED}[error]${NC} %s\n" "$1"; exit 1; }
+
+# Visible prompt (read -rp echoes input)
+prompt() { read -rp "$1" "$2" <&3; }
+
+# Hidden prompt for secrets (does not echo)
+prompt_secret() {
+    read -rsp "$1" "$2" <&3
+    printf '\n'
+}
+
+# Retry a command up to 3 times with brief backoff. Preserves args.
+retry() {
+    local n=1 max=3 delay=2
+    while true; do
+        if "$@"; then return 0; fi
+        if [ "$n" -ge "$max" ]; then return 1; fi
+        warn "Command failed (attempt ${n}/${max}), retrying in ${delay}s..."
+        sleep "$delay"
+        n=$((n + 1))
+        delay=$((delay * 2))
+    done
+}
+
+# ── CLI parsing ──────────────────────────────────────────────────────────────
+
+show_help() {
+    cat <<EOF
+Data 360 MCP Server installer v${INSTALLER_VERSION}
+
+Usage:
+  ./install.sh                  Install or upgrade
+  ./install.sh uninstall        Remove JAR and data360 entry from MCP configs
+  ./install.sh --help           Show this help
+  ./install.sh --version        Show installer version
+
+The installer will check for and install Java 17+, Maven, Git, and python3 as
+needed, build the server JAR, collect Salesforce credentials, and merge a
+data360 entry into your chosen MCP client config files.
+EOF
+}
+
+# ── Detect OS ────────────────────────────────────────────────────────────────
+
+detect_os() {
+    OS="$(uname -s)"
+    case "${OS}" in
+        Darwin) OS_TYPE="macos" ;;
+        Linux)  OS_TYPE="linux" ;;
+        *)      fail "Unsupported OS: ${OS}. This installer supports macOS and Linux." ;;
+    esac
+}
+
+# ── Check for Homebrew (macOS) ───────────────────────────────────────────────
+
+ensure_homebrew() {
+    if [ "${OS_TYPE}" != "macos" ]; then
+        return 0
+    fi
+    if command -v brew &>/dev/null; then
+        return 0
+    fi
+    info "Homebrew not found. Installing..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+    # Add to PATH for Apple Silicon and Intel Macs
+    if [ -f "/opt/homebrew/bin/brew" ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -f "/usr/local/bin/brew" ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+    ok "Homebrew installed"
+}
+
+# ── Check / Install Git ─────────────────────────────────────────────────────
+
+check_git() {
+    if command -v git &>/dev/null; then
+        return 0
+    fi
+    info "Git not found. Installing..."
+    if [ "${OS_TYPE}" = "macos" ]; then
+        ensure_homebrew
+        brew install git
+    else
+        if command -v apt-get &>/dev/null; then
+            retry sudo apt-get update -qq && sudo apt-get install -y -qq git
+        elif command -v yum &>/dev/null; then
+            sudo yum install -y -q git
+        else
+            fail "Cannot auto-install git. Please install it manually and re-run."
+        fi
+    fi
+    ok "Git installed"
+}
+
+# ── Check / Install Java 17+ ────────────────────────────────────────────────
+
+# Parse a Java major version from `java -version` output.
+# Handles both modern ("17.0.5") and legacy ("1.8.0_xxx") formats.
+# Echoes the major version, or "0" if unknown.
+java_major_version() {
+    local raw major
+    raw=$(java -version 2>&1 | awk -F'"' '/version/ {print $2; exit}')
+    [ -z "${raw}" ] && { echo 0; return; }
+    # Take first dotted component
+    major="${raw%%.*}"
+    # Legacy "1.8.0_xxx" → use second component
+    if [ "${major}" = "1" ]; then
+        major=$(printf '%s' "${raw}" | awk -F'.' '{print $2}')
+    fi
+    [[ "${major}" =~ ^[0-9]+$ ]] || major=0
+    echo "${major}"
+}
+
+check_java() {
+    info "Checking for Java 17+..."
+
+    if command -v java &>/dev/null; then
+        local java_version
+        java_version=$(java_major_version)
+        if [ "${java_version}" -ge 17 ] 2>/dev/null; then
+            ok "Java ${java_version} found"
+            return 0
+        else
+            warn "Java ${java_version} found, but 17+ is required"
+        fi
+    else
+        warn "Java not found"
+    fi
+
+    info "Installing Java 17..."
+    if [ "${OS_TYPE}" = "macos" ]; then
+        ensure_homebrew
+        brew install openjdk@17
+        if [ -d "$(brew --prefix)/opt/openjdk@17/bin" ]; then
+            export PATH="$(brew --prefix)/opt/openjdk@17/bin:${PATH}"
+        fi
+    else
+        if command -v apt-get &>/dev/null; then
+            retry sudo apt-get update -qq && sudo apt-get install -y -qq openjdk-17-jdk
+        elif command -v yum &>/dev/null; then
+            sudo yum install -y -q java-17-openjdk-devel
+        else
+            fail "Cannot auto-install Java. Please install Java 17+ manually and re-run."
+        fi
+    fi
+    ok "Java 17 installed"
+}
+
+# ── Check / Install Maven ───────────────────────────────────────────────────
+
+check_maven() {
+    info "Checking for Maven..."
+
+    if command -v mvn &>/dev/null; then
+        local mvn_version
+        mvn_version=$(mvn -v 2>&1 | awk '/Apache Maven/ {print $3; exit}')
+        ok "Maven found (${mvn_version})"
+        return 0
+    fi
+
+    info "Installing Maven..."
+    if [ "${OS_TYPE}" = "macos" ]; then
+        ensure_homebrew
+        brew install maven
+    else
+        if command -v apt-get &>/dev/null; then
+            retry sudo apt-get update -qq && sudo apt-get install -y -qq maven
+        elif command -v yum &>/dev/null; then
+            sudo yum install -y -q maven
+        else
+            fail "Cannot auto-install Maven. Please install it manually and re-run."
+        fi
+    fi
+    ok "Maven installed"
+}
+
+# ── Check / Install python3 ─────────────────────────────────────────────────
+
+check_python3() {
+    if command -v python3 &>/dev/null; then
+        return 0
+    fi
+    info "python3 not found. Installing..."
+    if [ "${OS_TYPE}" = "macos" ]; then
+        ensure_homebrew
+        brew install python3
+    else
+        if command -v apt-get &>/dev/null; then
+            retry sudo apt-get update -qq && sudo apt-get install -y -qq python3
+        elif command -v yum &>/dev/null; then
+            sudo yum install -y -q python3
+        else
+            fail "Cannot auto-install python3. Please install it manually and re-run."
+        fi
+    fi
+    ok "python3 installed"
+}
+
+# ── Build the JAR ───────────────────────────────────────────────────────────
+
+build_jar() {
+    mkdir -p "${INSTALL_DIR}"
+    chmod 700 "${INSTALL_DIR}"
+    local build_dir=""
+    local cloned_tmpdir=""
+
+    if [ -f "pom.xml" ] && grep -q "data360-mcp-server" pom.xml 2>/dev/null; then
+        info "Building from local repo..."
+        build_dir="."
+    else
+        check_git
+        cloned_tmpdir=$(mktemp -d)
+        info "Cloning repo..."
+        if ! git clone --depth 1 --branch "${REPO_BRANCH}" "${REPO_URL}" "${cloned_tmpdir}/d360-mcp-server" </dev/null 2>&1 | tail -5; then
+            printf "\n"
+            fail "Failed to clone ${REPO_URL}.
+    Possible causes:
+      • GitHub credentials not cached — try: gh auth login
+      • Repository access not granted — check github.com/forcedotcom/d360-mcp-server
+      • Network connectivity issue
+    Fix the above and re-run."
+        fi
+        build_dir="${cloned_tmpdir}/d360-mcp-server"
+    fi
+
+    info "Building JAR (this may take a minute on first run)..."
+    local build_log="${INSTALL_DIR}/build.log"
+    if ! (cd "${build_dir}" && mvn clean package -DskipTests) </dev/null > "${build_log}" 2>&1; then
+        printf "\n--- Last 40 lines of build log ---\n"
+        tail -40 "${build_log}"
+        printf "\n"
+        fail "Maven build failed. Full log: ${build_log}"
+    fi
+
+    # Glob the produced JAR — avoids hardcoding a version that drifts from pom.xml.
+    local jar=""
+    for candidate in "${build_dir}/target/"data360-mcp-server-*.jar; do
+        case "${candidate}" in
+            *.original) continue ;;
+        esac
+        [ -f "${candidate}" ] && jar="${candidate}" && break
+    done
+    [ -n "${jar}" ] || fail "Build succeeded but no JAR found in ${build_dir}/target/"
+
+    JAR_NAME=$(basename "${jar}")
+    cp "${jar}" "${INSTALL_DIR}/"
+    chmod 644 "${INSTALL_DIR}/${JAR_NAME}"
+
+    # Clean up temp dir if we cloned
+    if [ -n "${cloned_tmpdir}" ]; then
+        rm -rf "${cloned_tmpdir}"
+    fi
+
+    ok "JAR installed to ${INSTALL_DIR}/${JAR_NAME}"
+}
+
+# ── Credential reuse ────────────────────────────────────────────────────────
+
+# Try to load credentials from an existing MCP_CONFIG_FILE into the shell vars.
+# Returns 0 on success (AUTH_FLOW and relevant fields populated), 1 otherwise.
+load_existing_credentials() {
+    [ -f "${MCP_CONFIG_FILE}" ] || return 1
+
+    local parsed
+    parsed=$(python3 - "${MCP_CONFIG_FILE}" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    env = cfg["mcpServers"]["data360"]["env"]
+except Exception:
+    sys.exit(1)
+flow = env.get("DATA360_AUTH_FLOW", "access_token")
+print(f"FLOW={flow}")
+for k in ("DATA360_INSTANCE_URL", "DATA360_ACCESS_TOKEN",
+          "DATA360_CLIENT_ID", "DATA360_CLIENT_SECRET",
+          "DATA360_LOGIN_URL", "DATA360_API_VERSION"):
+    v = env.get(k, "")
+    # Shell-single-quote escape
+    v_esc = v.replace("'", "'\"'\"'")
+    print(f"{k}='{v_esc}'")
+PYEOF
+    ) || return 1
+
+    eval "${parsed}"
+    AUTH_FLOW="${FLOW:-access_token}"
+    return 0
+}
+
+# ── Collect credentials ─────────────────────────────────────────────────────
+
+# Normalize and validate a Salesforce instance URL.
+# Echoes the normalized value on success. Fails with a clear message otherwise.
+validate_instance_url() {
+    local url="$1"
+    # Strip trailing slashes
+    url="${url%/}"
+    if [[ ! "${url}" =~ ^https:// ]]; then
+        fail "Instance URL must start with https:// (got: '${url}')"
+    fi
+    # Reject anything with a path segment beyond host
+    local after_scheme="${url#*://}"
+    if [[ "${after_scheme}" == */* ]]; then
+        fail "Instance URL should be host-only, with no path (got: '${url}')"
+    fi
+    echo "${url}"
+}
+
+collect_credentials() {
+    # Offer to reuse stored credentials on re-run.
+    if load_existing_credentials; then
+        printf "\n${BOLD}Existing credentials detected${NC} for flow '%s'.\n" "${AUTH_FLOW}"
+        local reuse_choice=""
+        prompt "Reuse them? [Y/n]: " reuse_choice
+        case "${reuse_choice:-Y}" in
+            Y|y|Yes|yes|"") ok "Reusing stored credentials"; return 0 ;;
+        esac
+        # Fall through to fresh collection
+        unset DATA360_INSTANCE_URL DATA360_ACCESS_TOKEN
+        unset DATA360_CLIENT_ID DATA360_CLIENT_SECRET DATA360_LOGIN_URL
+        unset DATA360_API_VERSION AUTH_FLOW
+    fi
+
+    printf "\n"
+    printf "${BOLD}Salesforce Data 360 Credentials${NC}\n"
+    printf "Choose an auth method:\n"
+    printf "  1) Access token  — quick setup, tokens expire\n"
+    printf "  2) Client credentials  — auto-refreshing, recommended\n"
+    printf "\n"
+    prompt "Choose [1/2]: " auth_choice
+
+    case "${auth_choice}" in
+        1)
+            AUTH_FLOW="access_token"
+            local raw_url=""
+            prompt "DATA360_INSTANCE_URL (e.g. https://your-org.my.salesforce.com): " raw_url
+            [ -n "${raw_url}" ] || fail "Instance URL is required"
+            DATA360_INSTANCE_URL=$(validate_instance_url "${raw_url}")
+            prompt_secret "DATA360_ACCESS_TOKEN (hidden): " DATA360_ACCESS_TOKEN
+            [ -n "${DATA360_ACCESS_TOKEN}" ] || fail "Access token is required"
+            ;;
+        2)
+            AUTH_FLOW="client_credentials"
+            prompt "DATA360_CLIENT_ID: " DATA360_CLIENT_ID
+            [ -n "${DATA360_CLIENT_ID}" ] || fail "Client ID is required"
+            prompt_secret "DATA360_CLIENT_SECRET (hidden): " DATA360_CLIENT_SECRET
+            [ -n "${DATA360_CLIENT_SECRET}" ] || fail "Client secret is required"
+            local default_login="https://login.salesforce.com"
+            local input_login_url=""
+            prompt "DATA360_LOGIN_URL [${default_login}]: " input_login_url || true
+            DATA360_LOGIN_URL="${input_login_url:-${default_login}}"
+            ;;
+        *)
+            fail "Invalid choice"
+            ;;
+    esac
+
+    # Optional API version override
+    local input_api=""
+    prompt "DATA360_API_VERSION [${DEFAULT_API_VERSION}]: " input_api || true
+    DATA360_API_VERSION="${input_api:-${DEFAULT_API_VERSION}}"
+}
+
+# ── Build MCP server config snippet ─────────────────────────────────────────
+# Uses python3 for JSON construction so special characters in credentials
+# ($, ", backticks, !) are properly escaped.
+
+build_mcp_config() {
+    local jar_path="${INSTALL_DIR}/${JAR_NAME}"
+
+    if [ "${AUTH_FLOW}" = "access_token" ]; then
+        python3 - "${jar_path}" "${DATA360_INSTANCE_URL}" "${DATA360_ACCESS_TOKEN}" \
+                  "${DATA360_API_VERSION}" "${MCP_CONFIG_FILE}" <<'PYEOF'
+import json, sys
+jar, url, token, api_version, out = sys.argv[1:6]
+cfg = {"mcpServers": {"data360": {"command": "java", "args": ["-jar", jar], "env": {
+    "DATA360_AUTH_FLOW": "access_token",
+    "DATA360_INSTANCE_URL": url,
+    "DATA360_ACCESS_TOKEN": token,
+    "DATA360_API_VERSION": api_version,
+}}}}
+with open(out, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+PYEOF
+    else
+        python3 - "${jar_path}" "${DATA360_CLIENT_ID}" "${DATA360_CLIENT_SECRET}" \
+                  "${DATA360_LOGIN_URL}" "${DATA360_API_VERSION}" "${MCP_CONFIG_FILE}" <<'PYEOF'
+import json, sys
+jar, cid, secret, login, api_version, out = sys.argv[1:7]
+cfg = {"mcpServers": {"data360": {"command": "java", "args": ["-jar", jar], "env": {
+    "DATA360_AUTH_FLOW": "client_credentials",
+    "DATA360_CLIENT_ID": cid,
+    "DATA360_CLIENT_SECRET": secret,
+    "DATA360_LOGIN_URL": login,
+    "DATA360_API_VERSION": api_version,
+}}}}
+with open(out, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+PYEOF
+    fi
+
+    chmod 600 "${MCP_CONFIG_FILE}"
+    ok "MCP config generated"
+}
+
+# ── Configure MCP clients ───────────────────────────────────────────────────
+
+# Atomically merge the data360 entry into a JSON config file.
+# Takes a .bak snapshot before the first modification, writes to a tmp, then mv.
+merge_mcp_config() {
+    local config_file="$1"
+    local dir
+    dir=$(dirname "${config_file}")
+    mkdir -p "${dir}"
+
+    if [ -f "${config_file}" ]; then
+        # One-time backup, never overwrite an existing .bak to preserve original.
+        [ -f "${config_file}.bak" ] || cp -p "${config_file}" "${config_file}.bak"
+
+        local tmp="${config_file}.tmp.$$"
+        python3 - "${config_file}" "${MCP_CONFIG_FILE}" "${tmp}" <<'PYEOF'
+import json, sys
+config_file, new_file, tmp = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(config_file) as f:
+    existing = json.load(f)
+with open(new_file) as f:
+    new_server = json.load(f)
+existing.setdefault("mcpServers", {})
+existing["mcpServers"]["data360"] = new_server["mcpServers"]["data360"]
+with open(tmp, "w") as f:
+    json.dump(existing, f, indent=2)
+    f.write("\n")
+PYEOF
+        mv "${tmp}" "${config_file}"
+        chmod 600 "${config_file}"
+        ok "  Updated data360 in ${config_file} (backup: ${config_file}.bak)"
+    else
+        cp "${MCP_CONFIG_FILE}" "${config_file}"
+        chmod 600 "${config_file}"
+        ok "  Created ${config_file}"
+    fi
+}
+
+# Returns 0 if the given client is detected on this machine.
+client_present_claude_desktop() {
+    if [ "$(uname)" = "Darwin" ]; then
+        [ -d "${HOME}/Library/Application Support/Claude" ] || \
+        [ -d "/Applications/Claude.app" ]
+    else
+        [ -d "${HOME}/.config/Claude" ]
+    fi
+}
+client_present_claude_code() {
+    command -v claude &>/dev/null || [ -f "${HOME}/.claude.json" ]
+}
+client_present_cursor() {
+    [ -d "${HOME}/.cursor" ] || \
+    ([ "$(uname)" = "Darwin" ] && [ -d "/Applications/Cursor.app" ]) || \
+    command -v cursor &>/dev/null
+}
+
+configure_clients() {
+    printf "\n"
+    printf "${BOLD}Configure MCP Clients${NC}\n"
+
+    local cd_note="" cc_note="" cu_note=""
+    client_present_claude_desktop || cd_note="  (not detected)"
+    client_present_claude_code    || cc_note="  (not detected)"
+    client_present_cursor         || cu_note="  (not detected)"
+
+    printf "Which clients would you like to configure?\n"
+    printf "  1) Claude Desktop%s\n" "${cd_note}"
+    printf "  2) Claude Code%s\n" "${cc_note}"
+    printf "  3) Cursor%s\n" "${cu_note}"
+    printf "  4) All detected\n"
+    printf "  5) None — I'll configure manually\n"
+    printf "\n"
+    prompt "Choose [1/2/3/4/5]: " client_choice
+
+    case "${client_choice}" in
+        1) configure_claude_desktop ;;
+        2) configure_claude_code ;;
+        3) configure_cursor ;;
+        4)
+            client_present_claude_desktop && configure_claude_desktop || warn "Skipping Claude Desktop (not detected)"
+            client_present_claude_code    && configure_claude_code    || warn "Skipping Claude Code (not detected)"
+            client_present_cursor         && configure_cursor         || warn "Skipping Cursor (not detected)"
+            ;;
+        5)
+            printf "\n${BOLD}Manual configuration:${NC}\n"
+            printf "Your MCP server config was saved (with secrets) to:\n"
+            printf "  ${BOLD}%s${NC}\n\n" "${MCP_CONFIG_FILE}"
+            printf "Copy its contents into your MCP client's configuration.\n"
+            printf "(File permissions are 600 — do not print it in shared terminals.)\n"
+            ;;
+        *)
+            fail "Invalid choice"
+            ;;
+    esac
+}
+
+configure_claude_desktop() {
+    info "Configuring Claude Desktop..."
+    local config_file
+    if [ "$(uname)" = "Darwin" ]; then
+        config_file="${HOME}/Library/Application Support/Claude/claude_desktop_config.json"
+    else
+        config_file="${HOME}/.config/Claude/claude_desktop_config.json"
+    fi
+    merge_mcp_config "${config_file}"
+}
+
+configure_claude_code() {
+    info "Configuring Claude Code..."
+    # Prefer the supported CLI when available — Claude Code owns ~/.claude.json
+    # and may rewrite unrelated fields on its own.
+    if command -v claude &>/dev/null; then
+        local server_json
+        server_json=$(python3 - "${MCP_CONFIG_FILE}" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    cfg = json.load(f)
+print(json.dumps(cfg["mcpServers"]["data360"]))
+PYEOF
+        )
+        # Remove existing entry first to keep this idempotent
+        claude mcp remove data360 &>/dev/null || true
+        if claude mcp add-json --scope user data360 "${server_json}" </dev/null; then
+            ok "  Registered data360 via 'claude mcp add-json --scope user'"
+            return 0
+        fi
+        warn "'claude mcp add-json' failed — falling back to direct merge"
+    fi
+    local config_file="${HOME}/.claude.json"
+    merge_mcp_config "${config_file}"
+}
+
+configure_cursor() {
+    info "Configuring Cursor..."
+    local config_file="${HOME}/.cursor/mcp.json"
+    merge_mcp_config "${config_file}"
+}
+
+# ── Uninstall ────────────────────────────────────────────────────────────────
+
+remove_from_config() {
+    local config_file="$1"
+    [ -f "${config_file}" ] || return 0
+
+    local tmp="${config_file}.tmp.$$"
+    if python3 - "${config_file}" "${tmp}" <<'PYEOF'
+import json, sys
+config_file, tmp = sys.argv[1], sys.argv[2]
+try:
+    with open(config_file) as f:
+        cfg = json.load(f)
+except Exception:
+    sys.exit(2)
+servers = cfg.get("mcpServers", {})
+if "data360" in servers:
+    del servers["data360"]
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    sys.exit(0)
+sys.exit(3)  # nothing to remove
+PYEOF
+    then
+        mv "${tmp}" "${config_file}"
+        chmod 600 "${config_file}"
+        ok "  Removed data360 from ${config_file}"
+    else
+        rm -f "${tmp}"
+        info "  No data360 entry in ${config_file}"
+    fi
+}
+
+uninstall() {
+    printf "\n${BOLD}Uninstalling Data 360 MCP Server${NC}\n\n"
+
+    # Try claude CLI first for Claude Code
+    if command -v claude &>/dev/null; then
+        info "Removing from Claude Code (via CLI)..."
+        claude mcp remove data360 &>/dev/null && ok "  Removed via 'claude mcp remove'" || true
+    fi
+
+    local desktop_config
+    if [ "$(uname)" = "Darwin" ]; then
+        desktop_config="${HOME}/Library/Application Support/Claude/claude_desktop_config.json"
+    else
+        desktop_config="${HOME}/.config/Claude/claude_desktop_config.json"
+    fi
+
+    remove_from_config "${desktop_config}"
+    remove_from_config "${HOME}/.claude.json"
+    remove_from_config "${HOME}/.cursor/mcp.json"
+
+    if [ -d "${INSTALL_DIR}" ]; then
+        info "Removing ${INSTALL_DIR}..."
+        rm -rf "${INSTALL_DIR}"
+        ok "Removed install directory"
+    fi
+
+    printf "\n${GREEN}Uninstall complete.${NC}\n"
+    printf "Config backups (if any) remain at <config>.bak — remove them manually if desired.\n\n"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main_install() {
+    printf "\n"
+    printf "${BOLD}Data 360 MCP Server Installer${NC} (v${INSTALLER_VERSION})\n"
+    printf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"
+
+    detect_os
+    check_java
+    check_maven
+    check_python3
+    build_jar
+    collect_credentials
+    build_mcp_config
+    configure_clients
+
+    printf "\n"
+    printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+    printf "${GREEN}${BOLD}Installation complete!${NC}\n"
+    printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+    printf "\n"
+    printf "  JAR location:  ${INSTALL_DIR}/${JAR_NAME}\n"
+    printf "\n"
+    printf "  To test manually:\n"
+    printf "    java -jar ${INSTALL_DIR}/${JAR_NAME}\n"
+    printf "\n"
+    printf "  To update later:\n"
+    printf "    Re-run this script — it will rebuild from the current source\n"
+    printf "    and reuse your stored credentials.\n"
+    printf "\n"
+    printf "  To uninstall:\n"
+    printf "    ./install.sh uninstall\n"
+    printf "\n"
+}
+
+main() {
+    case "${1:-}" in
+        -h|--help)
+            show_help
+            ;;
+        -V|--version)
+            printf "install.sh v%s\n" "${INSTALLER_VERSION}"
+            ;;
+        uninstall)
+            uninstall
+            ;;
+        ""|install)
+            main_install
+            ;;
+        *)
+            printf "Unknown argument: %s\n\n" "$1" >&2
+            show_help
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `install.sh` (macOS/Linux) and `install.py` (cross-platform, including Windows) one-command installers that check/install Java 17+, Maven, and Git, build the server JAR from source, collect Salesforce credentials, and auto-configure Claude Desktop, Claude Code, and Cursor MCP client configs
- Updates README with Quick Start curl one-liner and Uninstall section
- All repo URLs updated to point to `github.com/forcedotcom/d360-mcp-server`

## Test plan
- [ ] Run `./install.sh` from a fresh clone on macOS and verify it builds and configures Claude Desktop
- [ ] Run `./install.sh uninstall` and verify cleanup
- [ ] Run `python3 install.py` on macOS/Linux and verify equivalent behavior
- [ ] Verify `curl -fsSL <raw URL> | bash` works for remote install
- [ ] Verify credential reuse on re-run (`./install.sh` a second time)