### PR TITLE
fix: add missing /ssot/ prefix to query, retriever, and search-index API paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `d360_query_sql`, `d360_query_sql_status`, `d360_query_sql_rows`, and
+  `d360_query_sql_cancel` now call `/services/data/vNN.0/ssot/query-sql*`
+  instead of `/services/data/vNN.0/query-sql*`. The previous paths returned
+  404 on live orgs.
+- `buildQueryPath` no longer double-prepends `/ssot/` now that callers pass
+  the full path.
+- Retriever and search-index tools now use `/ssot/machine-learning/retrievers`
+  and `/ssot/search-index` respectively (were missing the prefix after the
+  CdpClient→Data360Client consolidation).
+- `/ssot/` is no longer misplaced inside the calculated-insights sub-path of
+  `queryProfile`.
+
+### Removed
+
+- **Breaking:** `d360_query` (V1 ANSI SQL) and `d360_query_v2` are removed.
+  Use `d360_query_sql` instead.
+
 ## [1.0.0] - 2026-04-21
 
 ### Added

--- a/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
+++ b/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
@@ -111,7 +111,7 @@ public class FamilyCatalog {
         List<ToolDef> t = new ArrayList<>();
 
         // ── Query ──────────────────────────────────────────────────────────
-        t.add(new ToolDef("d360_query_sql", "Query", "Execute SQL query. Preferred over V1/V2. Supports parameterized queries.", "POST", "/ssot/query-sql"));
+        t.add(new ToolDef("d360_query_sql", "Query", "Execute SQL query. Supports parameterized queries.", "POST", "/ssot/query-sql"));
         t.add(new ToolDef("d360_query_sql_status", "Query", "Poll for long-running query status.", "GET", "/ssot/query-sql/{queryId}"));
         t.add(new ToolDef("d360_query_sql_rows", "Query", "Fetch paginated rows from completed query.", "GET", "/ssot/query-sql/{queryId}/rows"));
         t.add(new ToolDef("d360_query_sql_cancel", "Query", "Cancel a running query.", "DELETE", "/ssot/query-sql/{queryId}"));

--- a/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
+++ b/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
@@ -115,8 +115,6 @@ public class FamilyCatalog {
         t.add(new ToolDef("d360_query_sql_status", "Query", "Poll for long-running query status.", "GET", "/ssot/query-sql/{queryId}"));
         t.add(new ToolDef("d360_query_sql_rows", "Query", "Fetch paginated rows from completed query.", "GET", "/ssot/query-sql/{queryId}/rows"));
         t.add(new ToolDef("d360_query_sql_cancel", "Query", "Cancel a running query.", "DELETE", "/ssot/query-sql/{queryId}"));
-        t.add(new ToolDef("d360_query", "Query", "Legacy V1 query. Use d360_query_sql instead.", "POST", "/ssot/query"));
-        t.add(new ToolDef("d360_query_v2", "Query", "V2 ANSI SQL query. Still prefer d360_query_sql.", "POST", "/ssot/queryv2"));
         t.add(new ToolDef("d360_metadata", "Query", "Get metadata for entity. ALWAYS use entityName filter.", "GET", "/ssot/metadata"));
         t.add(new ToolDef("d360_metadata_search", "Query", "Search metadata using natural language. Preferred for discovery.", "POST", "/connect/search/metadata/results"));
         t.add(new ToolDef("d360_metadata_entities", "Query", "List paginated metadata entities. entityType required.", "GET", "/ssot/metadata-entities"));

--- a/src/main/java/com/salesforce/data360/mcp/service/QueryService.java
+++ b/src/main/java/com/salesforce/data360/mcp/service/QueryService.java
@@ -51,7 +51,7 @@ public class QueryService {
             }
             if (adaptiveTimeout != null) body.put("adaptiveTimeout", adaptiveTimeout);
 
-            String path = buildQueryPath("/query-sql", dataspace, workloadName, null);
+            String path = buildQueryPath("/ssot/query-sql", dataspace, workloadName, null);
             Map result = client.post(path, body, Map.class);
             return JsonUtil.toJson(result);
         } catch (IllegalArgumentException | ApiException e) {
@@ -64,7 +64,7 @@ public class QueryService {
             Map<String, Object> params = new LinkedHashMap<>();
             if (waitTimeMs != null) params.put("waitTimeMs", waitTimeMs);
 
-            String path = buildQueryPath("/query-sql/" + ToolUtils.encodePath(queryId), dataspace, workloadName, params);
+            String path = buildQueryPath("/ssot/query-sql/" + ToolUtils.encodePath(queryId), dataspace, workloadName, params);
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -80,7 +80,7 @@ public class QueryService {
             if (rowLimit != null) params.put("rowLimit", rowLimit);
             if (omitSchema != null) params.put("omitSchema", omitSchema);
 
-            String path = buildQueryPath("/query-sql/" + ToolUtils.encodePath(queryId) + "/rows", dataspace, workloadName, params);
+            String path = buildQueryPath("/ssot/query-sql/" + ToolUtils.encodePath(queryId) + "/rows", dataspace, workloadName, params);
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -90,55 +90,9 @@ public class QueryService {
 
     public String cancelQuerySql(String queryId, String dataspace, String workloadName) {
         try {
-            String path = buildQueryPath("/query-sql/" + ToolUtils.encodePath(queryId), dataspace, workloadName, null);
+            String path = buildQueryPath("/ssot/query-sql/" + ToolUtils.encodePath(queryId), dataspace, workloadName, null);
             Map result = client.delete(path, Map.class);
             return JsonUtil.toJson(result);
-        } catch (ApiException e) {
-            return ToolUtils.errorResponse(e);
-        }
-    }
-
-    public String queryAnsiSql(String sql, Integer batchSize, Integer offset,
-                               String orderby, String dataspace) {
-        try {
-            Map<String, Object> body = Map.of("sql", sql);
-
-            Map<String, Object> params = new LinkedHashMap<>();
-            if (batchSize != null) params.put("batchSize", batchSize);
-            if (offset != null) params.put("offset", offset);
-            if (orderby != null) params.put("orderby", orderby);
-
-            String path = buildQueryPath("/query", dataspace, null, params);
-            Map result = client.post(path, body, Map.class);
-            return JsonUtil.toJson(result);
-        } catch (ApiException e) {
-            return ToolUtils.errorResponse(e);
-        }
-    }
-
-    public String queryAnsiSqlV2(String sql, String nextBatchId, String dataspace) {
-        try {
-            boolean hasSql = sql != null && !sql.isBlank();
-            boolean hasNextBatchId = nextBatchId != null && !nextBatchId.isBlank();
-            if (!hasSql && !hasNextBatchId) {
-                return JsonUtil.toJson(Map.of(
-                    "error", "Either sql or nextBatchId must be provided."
-                ));
-            }
-
-            Map<String, Object> params = new LinkedHashMap<>();
-            if (dataspace != null) params.put("dataspace", dataspace);
-
-            if (hasNextBatchId) {
-                String path = ToolUtils.buildPath("/ssot/queryv2/" + ToolUtils.encodePath(nextBatchId), params);
-                Map result = client.get(path, Map.class);
-                return JsonUtil.toJson(result);
-            } else {
-                Map<String, Object> body = Map.of("sql", sql);
-                String path = ToolUtils.buildPath("/ssot/queryv2", params);
-                Map result = client.post(path, body, Map.class);
-                return JsonUtil.toJson(result);
-            }
         } catch (ApiException e) {
             return ToolUtils.errorResponse(e);
         }
@@ -149,12 +103,12 @@ public class QueryService {
                                Integer batchSize, String filters, Integer offset,
                                String orderby, String dataspace) {
         try {
-            StringBuilder pathBuilder = new StringBuilder("/profile/").append(ToolUtils.encodePath(dataModelName));
+            StringBuilder pathBuilder = new StringBuilder("/ssot/profile/").append(ToolUtils.encodePath(dataModelName));
 
             if (id != null) {
                 pathBuilder.append("/").append(ToolUtils.encodePath(id));
                 if (ciName != null) {
-                    pathBuilder.append("/ssot/calculated-insights/").append(ToolUtils.encodePath(ciName));
+                    pathBuilder.append("/calculated-insights/").append(ToolUtils.encodePath(ciName));
                 } else if (childDataModelName != null) {
                     pathBuilder.append("/").append(ToolUtils.encodePath(childDataModelName));
                 }
@@ -179,7 +133,7 @@ public class QueryService {
 
     public String getProfileMetadata(String dataModelName, String dataspace) {
         try {
-            StringBuilder pathBuilder = new StringBuilder("/profile/metadata");
+            StringBuilder pathBuilder = new StringBuilder("/ssot/profile/metadata");
             if (dataModelName != null) {
                 pathBuilder.append("/").append(ToolUtils.encodePath(dataModelName));
             }

--- a/src/main/java/com/salesforce/data360/mcp/tools/QueryTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/QueryTools.java
@@ -89,32 +89,6 @@ public class QueryTools {
     }
 
     @McpTool(
-        name = "d360_query",
-        description = "Execute ANSI SQL query against Data 360 (V1 legacy). Use d360_query_sql instead for new work."
-    )
-    public String queryAnsiSql(
-        @McpToolParam(description = "The ANSI SQL query to execute") String sql,
-        @McpToolParam(description = "Batch size for pagination", required = false) Integer batchSize,
-        @McpToolParam(description = "Offset for pagination", required = false) Integer offset,
-        @McpToolParam(description = "Order by clause", required = false) String orderby,
-        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
-    ) {
-        return queryService.queryAnsiSql(sql, batchSize, offset, orderby, dataspace);
-    }
-
-    @McpTool(
-        name = "d360_query_v2",
-        description = "Execute ANSI SQL V2 query or fetch next batch. Supports nextBatchId for pagination."
-    )
-    public String queryAnsiSqlV2(
-        @McpToolParam(description = "The ANSI SQL query to execute (optional if using nextBatchId)", required = false) String sql,
-        @McpToolParam(description = "Next batch ID for pagination (optional if using sql)", required = false) String nextBatchId,
-        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
-    ) {
-        return queryService.queryAnsiSqlV2(sql, nextBatchId, dataspace);
-    }
-
-    @McpTool(
         name = "d360_profile_query",
         description = "Query unified profile data. Supports searching by model name, ID, child models, and calculated insights on profiles."
     )

--- a/src/main/java/com/salesforce/data360/mcp/tools/QueryTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/QueryTools.java
@@ -34,16 +34,28 @@ public class QueryTools {
 
     @McpTool(
         name = "d360_query_sql",
-        description = "Execute a Data 360 SQL query (V3 API - preferred). Returns metadata, status, and first chunk of data. Use d360_query_sql_rows to paginate."
+        description = "Execute a SQL query against Salesforce Data 360 (formerly Data Cloud) and return the results. "
+            + "Data 360 SQL is PostgreSQL-flavored but has its own dialect, supported functions, and constraints. "
+            + "For authoritative syntax, supported functions, and semantics, consult the Data 360 SQL Reference: "
+            + "https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html "
+            + "Returns metadata, status, and first chunk of data. Use d360_query_sql_rows to paginate."
     )
     public String querySql(
-        @McpToolParam(description = "The DC SQL query to execute") String sql,
-        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace,
-        @McpToolParam(description = "Optional workload name", required = false) String workloadName,
-        @McpToolParam(description = "Max rows to return in first response", required = false) Integer rowLimit,
-        @McpToolParam(description = "Key-value map of query settings", required = false) Map<String, String> querySettings,
-        @McpToolParam(description = "JSON string of parameterized query values (array)", required = false) String sqlParameters,
-        @McpToolParam(description = "Adaptive timeout in milliseconds", required = false) Integer adaptiveTimeout
+        @McpToolParam(description = "A SQL query in the Data 360 SQL dialect (PostgreSQL-flavored). "
+            + "Always quote all identifiers and preserve their exact casing. "
+            + "Before writing a query, verify the tables and fields to use via d360_metadata_search "
+            + "(or, if unavailable, via d360_metadata_entities / d360_metadata). "
+            + "When in doubt about supported syntax or functions, refer to the Data 360 SQL Reference: "
+            + "https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html") String sql,
+        @McpToolParam(description = "The Data 360 dataspace to execute against. Defaults to 'default'.", required = false) String dataspace,
+        @McpToolParam(description = "Optional workload name for query resource management.", required = false) String workloadName,
+        @McpToolParam(description = "Max rows to return in the first response. Use d360_query_sql_rows to fetch additional pages.", required = false) Integer rowLimit,
+        @McpToolParam(description = "Optional Data 360 query settings, passed through as-is as 'querySettings' in the request body. "
+            + "Known settings include 'query_timeout' with a duration-suffixed value, e.g. {\"query_timeout\": \"1800000ms\"}. "
+            + "Leave unset to use Data 360 defaults.", required = false) Map<String, String> querySettings,
+        @McpToolParam(description = "JSON string of parameterized query values (array). "
+            + "Example: '[{\"name\":\"myParam\",\"value\":\"foo\"}]'. Reference parameters in the SQL as ':myParam'.", required = false) String sqlParameters,
+        @McpToolParam(description = "Adaptive timeout in milliseconds — how long the server waits before returning a partial/polling response.", required = false) Integer adaptiveTimeout
     ) {
         return queryService.querySql(sql, dataspace, workloadName, rowLimit, querySettings, sqlParameters, adaptiveTimeout);
     }

--- a/src/main/java/com/salesforce/data360/mcp/tools/RetrieverTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/RetrieverTools.java
@@ -39,7 +39,7 @@ import java.util.Map;
 @Component
 public class RetrieverTools {
 
-    private static final String BASE_PATH = "/machine-learning/retrievers";
+    private static final String BASE_PATH = "/ssot/machine-learning/retrievers";
 
     private final Data360Client client;
 

--- a/src/main/java/com/salesforce/data360/mcp/tools/SearchIndexTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/SearchIndexTools.java
@@ -50,7 +50,7 @@ public class SearchIndexTools {
     )
     public String listSearchIndexes() {
         try {
-            String path = "/search-index";
+            String path = "/ssot/search-index";
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -75,7 +75,7 @@ public class SearchIndexTools {
         try {
             Map<String, Object> body = JsonUtil.toMap(request);
 
-            String path = "/search-index";
+            String path = "/ssot/search-index";
             Map result = client.post(path, body, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -92,7 +92,7 @@ public class SearchIndexTools {
     )
     public String getSearchIndexConfig() {
         try {
-            String path = "/search-index/config";
+            String path = "/ssot/search-index/config";
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -111,7 +111,7 @@ public class SearchIndexTools {
         @McpToolParam(description = "ID or API Name of the search index") String searchIndexApiNameOrId
     ) {
         try {
-            String path = "/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
+            String path = "/ssot/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -130,7 +130,7 @@ public class SearchIndexTools {
         @McpToolParam(description = "ID or API Name of the search index") String searchIndexApiNameOrId
     ) {
         try {
-            String path = "/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
+            String path = "/ssot/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
             Map result = client.delete(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -157,7 +157,7 @@ public class SearchIndexTools {
             params.put("limit", limit != null ? limit : 50);
             params.put("offset", (offset != null && offset >= 1) ? offset : 1);
             String path = ToolUtils.buildPath(
-                "/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId) + "/process-history",
+                "/ssot/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId) + "/process-history",
                 params);
             Map result = client.get(path, Map.class);
             return JsonUtil.toJson(result);
@@ -182,7 +182,7 @@ public class SearchIndexTools {
         try {
             Map<String, Object> body = JsonUtil.toMap(request);
 
-            String path = "/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
+            String path = "/ssot/search-index/" + ToolUtils.encodePath(searchIndexApiNameOrId);
             Map result = client.patch(path, body, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {

--- a/src/test/java/com/salesforce/data360/mcp/service/QueryServiceTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/service/QueryServiceTest.java
@@ -71,7 +71,7 @@ class QueryServiceTest {
 
         verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/query-sql?dataspace=default");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/query-sql?dataspace=default");
         assertThat(bodyCaptor.getValue()).containsEntry("sql", sql);
         assertThat(bodyCaptor.getValue()).containsEntry("rowLimit", rowLimit);
     }
@@ -101,7 +101,7 @@ class QueryServiceTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123", "dataspace=default", "waitTimeMs=5000");
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123", "dataspace=default", "waitTimeMs=5000");
     }
 
     @Test
@@ -115,67 +115,6 @@ class QueryServiceTest {
 
         // Then
         assertThat(result).contains("error", "Invalid SQL", "400");
-    }
-
-    @Test
-    void queryAnsiSqlV2_requiresSqlOrNextBatchId() {
-        // When - pass both null
-        String result = queryService.queryAnsiSqlV2(null, null, "default");
-
-        // Then
-        assertThat(result).contains("error", "sql", "nextBatchId");
-        verifyNoInteractions(client);
-    }
-
-    @Test
-    void queryAnsiSqlV2_withSql() {
-        // Given
-        String sql = "SELECT * FROM Individual__dlm";
-        String dataspace = "default";
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", Map.of("rows", java.util.List.of()),
-            "nextBatchId", "batch-123"
-        );
-
-        when(client.post(anyString(), any(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryService.queryAnsiSqlV2(sql, null, dataspace);
-
-        // Then
-        assertThat(result).contains("nextBatchId");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/ssot/queryv2");
-    }
-
-    @Test
-    void queryAnsiSqlV2_withNextBatchId() {
-        // Given
-        String nextBatchId = "batch-123";
-        String dataspace = "default";
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", Map.of("rows", java.util.List.of())
-        );
-
-        when(client.get(anyString(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryService.queryAnsiSqlV2(null, nextBatchId, dataspace);
-
-        // Then
-        assertThat(result).contains("data");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).get(pathCaptor.capture(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/ssot/queryv2/batch-123");
     }
 
     @Test
@@ -201,7 +140,7 @@ class QueryServiceTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123/rows", "offset=0", "rowLimit=100");
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123/rows", "offset=0", "rowLimit=100");
     }
 
     @Test
@@ -224,33 +163,7 @@ class QueryServiceTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123", "dataspace=default");
-    }
-
-    @Test
-    void queryAnsiSql_success() {
-        // Given
-        String sql = "SELECT * FROM Individual__dlm";
-        Integer batchSize = 50;
-        String dataspace = "default";
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", java.util.List.of()
-        );
-
-        when(client.post(anyString(), any(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryService.queryAnsiSql(sql, batchSize, null, null, dataspace);
-
-        // Then
-        assertThat(result).contains("data");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/query", "batchSize=50", "dataspace=default");
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123", "dataspace=default");
     }
 
     @Test
@@ -275,7 +188,7 @@ class QueryServiceTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/Individual");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/Individual");
     }
 
     @Test
@@ -299,7 +212,7 @@ class QueryServiceTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/metadata", "dataspace=default");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/metadata", "dataspace=default");
     }
 
     @Test

--- a/src/test/java/com/salesforce/data360/mcp/tools/IntegrationTestBase.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/IntegrationTestBase.java
@@ -95,7 +95,6 @@ public abstract class IntegrationTestBase {
             "d360_metadata", "d360_metadata_entities", "d360_metadata_search",
             // Query
             "d360_query_sql", "d360_query_sql_status", "d360_query_sql_rows",
-            "d360_query", "d360_query_v2",
             // Profile
             "d360_profile_query", "d360_profile_metadata",
             // Insights

--- a/src/test/java/com/salesforce/data360/mcp/tools/QueryToolsTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/QueryToolsTest.java
@@ -77,7 +77,7 @@ class QueryToolsTest {
             eq(Map.class)
         );
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/query-sql?dataspace=default");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/query-sql?dataspace=default");
     }
 
     @Test
@@ -155,7 +155,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123", "dataspace=default", "waitTimeMs=5000");
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123", "dataspace=default", "waitTimeMs=5000");
     }
 
     @Test
@@ -181,7 +181,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123/rows", "offset=0", "rowLimit=100");
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123/rows", "offset=0", "rowLimit=100");
     }
 
     @Test
@@ -204,92 +204,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/query-sql/query-123", "dataspace=default");
-    }
-
-    @Test
-    void testQueryAnsiSql_success() {
-        // Given
-        String sql = "SELECT * FROM Individual__dlm";
-        Integer batchSize = 50;
-        String dataspace = DEFAULT_DATASPACE;
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", java.util.List.of()
-        );
-
-        when(client.post(anyString(), any(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryTools.queryAnsiSql(sql, batchSize, null, null, dataspace);
-
-        // Then
-        assertThat(result).contains("data");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/query", "batchSize=50", "dataspace=default");
-    }
-
-    @Test
-    void testQueryAnsiSqlV2_withSql() {
-        // Given
-        String sql = "SELECT * FROM Individual__dlm";
-        String dataspace = DEFAULT_DATASPACE;
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", java.util.List.of(),
-            "nextBatchId", "batch-123"
-        );
-
-        when(client.post(anyString(), any(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryTools.queryAnsiSqlV2(sql, null, dataspace);
-
-        // Then
-        assertThat(result).contains("nextBatchId");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/ssot/queryv2");
-    }
-
-    @Test
-    void testQueryAnsiSqlV2_withNextBatchId() {
-        // Given
-        String nextBatchId = "batch-123";
-        String dataspace = DEFAULT_DATASPACE;
-
-        Map<String, Object> mockResponse = Map.of(
-            "data", java.util.List.of()
-        );
-
-        when(client.get(anyString(), eq(Map.class)))
-            .thenReturn(mockResponse);
-
-        // When
-        String result = queryTools.queryAnsiSqlV2(null, nextBatchId, dataspace);
-
-        // Then
-        assertThat(result).contains("data");
-
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(client).get(pathCaptor.capture(), eq(Map.class));
-
-        assertThat(pathCaptor.getValue()).contains("/ssot/queryv2/batch-123");
-    }
-
-    @Test
-    void testQueryAnsiSqlV2_requiresSqlOrNextBatchId() {
-        String result = queryTools.queryAnsiSqlV2(null, null, DEFAULT_DATASPACE);
-
-        assertThat(result).contains("error", "sql", "nextBatchId");
-        verifyNoInteractions(client);
+        assertThat(pathCaptor.getValue()).contains("/ssot/query-sql/query-123", "dataspace=default");
     }
 
     @Test
@@ -314,7 +229,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/Individual");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/Individual");
     }
 
     @Test
@@ -339,7 +254,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/Individual/0014x000001234");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/Individual/0014x000001234");
     }
 
     @Test
@@ -363,7 +278,7 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/metadata", "dataspace=default");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/metadata", "dataspace=default");
     }
 
     @Test
@@ -387,12 +302,8 @@ class QueryToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/profile/metadata/Individual");
+        assertThat(pathCaptor.getValue()).contains("/ssot/profile/metadata/Individual");
     }
-
-    // ============================================================
-    // Data Graph Tools Tests
-    // ============================================================
 
     @Test
     void testQueryDataGraph_success() {

--- a/src/test/java/com/salesforce/data360/mcp/tools/RetrieverToolsTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/RetrieverToolsTest.java
@@ -71,7 +71,7 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers");
     }
 
     @Test
@@ -95,7 +95,7 @@ class RetrieverToolsTest {
     @Test
     void testListRetrievers_apiError() {
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(403, "Forbidden", "/machine-learning/retrievers"));
+            .thenThrow(new ApiException(403, "Forbidden", "/ssot/machine-learning/retrievers"));
 
         String result = retrieverTools.listRetrievers(null, null, null, null, null, null, null, null, null);
 
@@ -134,13 +134,13 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever");
     }
 
     @Test
     void testGetRetriever_notFound() {
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(404, "Not found", "/machine-learning/retrievers/nonexistent"));
+            .thenThrow(new ApiException(404, "Not found", "/ssot/machine-learning/retrievers/nonexistent"));
 
         String result = retrieverTools.getRetriever("nonexistent");
 
@@ -184,7 +184,7 @@ class RetrieverToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers");
         assertThat(bodyCaptor.getValue()).containsEntry("label", "TestRetriever");
         assertThat(bodyCaptor.getValue()).containsEntry("description", "A test retriever");
         assertThat(bodyCaptor.getValue()).containsEntry("dataSourceType", "SearchIndex");
@@ -193,7 +193,7 @@ class RetrieverToolsTest {
     @Test
     void testCreateRetriever_apiError() {
         when(client.post(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(400, "Bad request", "/machine-learning/retrievers"));
+            .thenThrow(new ApiException(400, "Bad request", "/ssot/machine-learning/retrievers"));
 
         RetrieverCreateRequest request = new RetrieverCreateRequest();
         request.setLabel("Bad");
@@ -239,7 +239,7 @@ class RetrieverToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).patch(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever");
         assertThat(bodyCaptor.getValue()).containsEntry("label", "Updated Label");
         assertThat(bodyCaptor.getValue()).containsEntry("description", "Updated description");
     }
@@ -247,7 +247,7 @@ class RetrieverToolsTest {
     @Test
     void testUpdateRetriever_apiError() {
         when(client.patch(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(404, "Not found", "/machine-learning/retrievers/nonexistent"));
+            .thenThrow(new ApiException(404, "Not found", "/ssot/machine-learning/retrievers/nonexistent"));
 
         RetrieverUpdateRequest request = new RetrieverUpdateRequest();
         request.setLabel("Test");
@@ -287,12 +287,12 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture());
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever");
     }
 
     @Test
     void testDeleteRetriever_apiError() {
-        doThrow(new ApiException(404, "Not found", "/machine-learning/retrievers/nonexistent"))
+        doThrow(new ApiException(404, "Not found", "/ssot/machine-learning/retrievers/nonexistent"))
             .when(client).delete(anyString());
 
         String result = retrieverTools.deleteRetriever("nonexistent");
@@ -332,7 +332,7 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever/configurations");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever/configurations");
     }
 
     @Test
@@ -351,7 +351,7 @@ class RetrieverToolsTest {
     @Test
     void testListRetrieverConfigurations_apiError() {
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(404, "Retriever not found", "/machine-learning/retrievers/bad/configurations"));
+            .thenThrow(new ApiException(404, "Retriever not found", "/ssot/machine-learning/retrievers/bad/configurations"));
 
         String result = retrieverTools.listRetrieverConfigurations("bad", null, null);
 
@@ -379,13 +379,13 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever/configurations/config_v1");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever/configurations/config_v1");
     }
 
     @Test
     void testGetRetrieverConfiguration_notFound() {
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(404, "Configuration not found", "/machine-learning/retrievers/MyRetriever/configurations/bad"));
+            .thenThrow(new ApiException(404, "Configuration not found", "/ssot/machine-learning/retrievers/MyRetriever/configurations/bad"));
 
         String result = retrieverTools.getRetrieverConfiguration("MyRetriever", "bad");
 
@@ -420,7 +420,7 @@ class RetrieverToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever/configurations");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever/configurations");
         assertThat(bodyCaptor.getValue()).containsEntry("queryType", "NoCode");
         assertThat(bodyCaptor.getValue()).containsEntry("isActive", true);
         assertThat(bodyCaptor.getValue()).containsEntry("numberOfResults", 5);
@@ -429,7 +429,7 @@ class RetrieverToolsTest {
     @Test
     void testCreateRetrieverConfiguration_apiError() {
         when(client.post(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(400, "Invalid configuration", "/machine-learning/retrievers/MyRetriever/configurations"));
+            .thenThrow(new ApiException(400, "Invalid configuration", "/ssot/machine-learning/retrievers/MyRetriever/configurations"));
 
         RetrieverConfigurationCreateRequest request = new RetrieverConfigurationCreateRequest();
         request.setQueryType("Invalid");
@@ -475,14 +475,14 @@ class RetrieverToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).patch(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever/configurations/config_v1");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever/configurations/config_v1");
         assertThat(bodyCaptor.getValue()).containsEntry("isActive", true);
     }
 
     @Test
     void testUpdateRetrieverConfiguration_apiError() {
         when(client.patch(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(409, "Conflict", "/machine-learning/retrievers/MyRetriever/configurations/config_v1"));
+            .thenThrow(new ApiException(409, "Conflict", "/ssot/machine-learning/retrievers/MyRetriever/configurations/config_v1"));
 
         RetrieverConfigurationUpdateRequest request = new RetrieverConfigurationUpdateRequest();
         request.setIsActive(true);
@@ -509,12 +509,12 @@ class RetrieverToolsTest {
 
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture());
-        assertThat(pathCaptor.getValue()).isEqualTo("/machine-learning/retrievers/MyRetriever/configurations/config_v1");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/machine-learning/retrievers/MyRetriever/configurations/config_v1");
     }
 
     @Test
     void testDeleteRetrieverConfiguration_apiError() {
-        doThrow(new ApiException(404, "Not found", "/machine-learning/retrievers/MyRetriever/configurations/bad"))
+        doThrow(new ApiException(404, "Not found", "/ssot/machine-learning/retrievers/MyRetriever/configurations/bad"))
             .when(client).delete(anyString());
 
         String result = retrieverTools.deleteRetrieverConfiguration("MyRetriever", "bad");

--- a/src/test/java/com/salesforce/data360/mcp/tools/SearchIndexToolsTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/SearchIndexToolsTest.java
@@ -76,14 +76,14 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index");
     }
 
     @Test
     void testListSearchIndexes_errorHandling() {
         // Given
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(403, "User does not have permission to access", "/search-index"));
+            .thenThrow(new ApiException(403, "User does not have permission to access", "/ssot/search-index"));
 
         // When
         String result = searchIndexTools.listSearchIndexes();
@@ -155,7 +155,7 @@ class SearchIndexToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index");
         assertThat(bodyCaptor.getValue()).containsEntry("label", "Case_search_index");
         assertThat(bodyCaptor.getValue()).containsEntry("searchType", "VECTOR");
         assertThat(bodyCaptor.getValue()).containsEntry("sourceDmoDeveloperName", "ssot__Case__dlm");
@@ -165,7 +165,7 @@ class SearchIndexToolsTest {
     void testCreateSearchIndex_errorHandling() {
         // Given
         when(client.post(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(400, "Bad request", "/search-index"));
+            .thenThrow(new ApiException(400, "Bad request", "/ssot/search-index"));
 
         // When
         SearchIndexCreateRequest request = new SearchIndexCreateRequest();
@@ -201,14 +201,14 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index/config");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index/config");
     }
 
     @Test
     void testGetSearchIndexConfig_errorHandling() {
         // Given
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(500, "Server error", "/search-index/config"));
+            .thenThrow(new ApiException(500, "Server error", "/ssot/search-index/config"));
 
         // When
         String result = searchIndexTools.getSearchIndexConfig();
@@ -243,14 +243,14 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index/idx-123");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index/idx-123");
     }
 
     @Test
     void testGetSearchIndex_notFound() {
         // Given
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(422, "Unprocessable entity", "/search-index/nonexistent"));
+            .thenThrow(new ApiException(422, "Unprocessable entity", "/ssot/search-index/nonexistent"));
 
         // When
         String result = searchIndexTools.getSearchIndex("nonexistent");
@@ -281,14 +281,14 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index/idx-123");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index/idx-123");
     }
 
     @Test
     void testDeleteSearchIndex_errorHandling() {
         // Given
         when(client.delete(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(403, "User does not have permission", "/search-index/idx-123"));
+            .thenThrow(new ApiException(403, "User does not have permission", "/ssot/search-index/idx-123"));
 
         // When
         String result = searchIndexTools.deleteSearchIndex("idx-123");
@@ -348,7 +348,7 @@ class SearchIndexToolsTest {
         ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
         verify(client).patch(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index/idx-123");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index/idx-123");
         assertThat(bodyCaptor.getValue()).containsEntry("label", "Updated_search_index");
     }
 
@@ -356,7 +356,7 @@ class SearchIndexToolsTest {
     void testUpdateSearchIndex_errorHandling() {
         // Given
         when(client.patch(anyString(), any(), eq(Map.class)))
-            .thenThrow(new ApiException(400, "Invalid request", "/search-index/idx-123"));
+            .thenThrow(new ApiException(400, "Invalid request", "/ssot/search-index/idx-123"));
 
         // When
         SearchIndexCreateRequest request = new SearchIndexCreateRequest();
@@ -411,7 +411,7 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/search-index/idx-123/process-history?limit=50&offset=1");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/search-index/idx-123/process-history?limit=50&offset=1");
     }
 
     @Test
@@ -429,14 +429,14 @@ class SearchIndexToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).get(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).contains("/search-index/idx-123/process-history", "limit=10", "offset=20");
+        assertThat(pathCaptor.getValue()).contains("/ssot/search-index/idx-123/process-history", "limit=10", "offset=20");
     }
 
     @Test
     void testGetSearchIndexProcessHistory_errorHandling() {
         // Given
         when(client.get(anyString(), eq(Map.class)))
-            .thenThrow(new ApiException(404, "Not found", "/search-index/nonexistent/process-history"));
+            .thenThrow(new ApiException(404, "Not found", "/ssot/search-index/nonexistent/process-history"));
 
         // When
         String result = searchIndexTools.getSearchIndexProcessHistory("nonexistent", null, null);


### PR DESCRIPTION
## Summary
- Fix missing `/ssot/` prefix in query, retriever, and search-index API paths after the CdpClient→Data360Client consolidation
- Fix misplaced `/ssot/` segment in the calculated-insights sub-path within `queryProfile`
- Remove deprecated V1/V2 query tools (`d360_query`, `d360_query_v2`) superseded by `d360_query_sql`
- Fix double `/ssot/` prefix in `buildQueryPath`

## Test plan
- [x] Unit tests updated for QueryService, QueryTools, RetrieverTools, and SearchIndexTools
- [ ] Verify query, retriever, and search-index API calls hit correct endpoints in integration environment