### PR TITLE
Add sf_cli auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `sf_cli` authentication mode — set `SF_ORG_ALIAS` (or `DATA360_SF_ORG_ALIAS`)
+  to an alias already authenticated via `sf org login web`. The server shells
+  out to `sf org display --target-org <alias> --json` on demand and caches the
+  token for 5 minutes. No Connected App setup required.
+
 ## [1.0.0] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,19 +72,23 @@ This produces `target/data360-mcp-server-1.0.0.jar`.
 
 ## Authentication
 
-The server auto-detects an auth flow from environment variables. Priority:
-`access_token` → `client_credentials`.
+The server auto-detects an auth flow from environment variables. Resolver priority:
+`access_token` → `client_credentials` → `sf_cli`. (The "Getting credentials"
+section below lists the options by convenience, which is the inverse order.)
 
 ### Getting credentials
 
 The server needs credentials for a Salesforce org with Data 360 enabled.
-You have two options, in order of convenience:
+You have three options, in order of convenience:
 
-1. **Access token** — the quickest way to try the server. Run `sf org login web`
-   (or the equivalent in your org tooling) and grab the access token from your
-   session. Tokens expire; for anything beyond experimentation, use the
-   option below.
-2. **External Client App with client credentials** — create an External Client
+1. **SF CLI alias** — if you already use `sf` to log into the org, just point
+   the server at that alias. The server shells out to
+   `sf org display --target-org <alias> --json` on demand and refreshes every
+   five minutes. No Connected App setup; no tokens to paste. See
+   [SF CLI auth](#sf-cli-auth-sfcli) below.
+2. **Access token** — paste a one-off access token. Quickest way to try the
+   server once, but tokens expire.
+3. **External Client App with client credentials** — create an External Client
    App in Setup, enable the Client Credentials flow, grant the `api`, `cdp_api` and
    `cdp_query_api` scopes, and use the resulting Consumer Key / Secret. The
    server will refresh tokens automatically. See
@@ -114,6 +118,25 @@ If you're using the `sf` cli you can initialize these automatically and create a
   ```
 
 Replacing `target-org-alias` with the `sf` cli's alias for your connected org.
+
+**SF CLI auth (`sf_cli`):**
+
+Requires the [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli)
+on PATH and an authenticated org:
+
+```bash
+sf org login web --alias myorg
+export SF_ORG_ALIAS="myorg"   # or DATA360_SF_ORG_ALIAS
+# Unset any leftover DATA360_ACCESS_TOKEN so the SF CLI path is selected.
+unset DATA360_ACCESS_TOKEN
+java -jar target/data360-mcp-server-1.0.0.jar
+```
+
+The server shells out to `sf org display --target-org <alias> --json` to
+obtain a token and instance URL, and caches the result for five minutes before
+re-asking `sf`. Works with any org the CLI is already authenticated against
+(scratch orgs, sandboxes, production). Precedence: if both `DATA360_ACCESS_TOKEN`
+and `SF_ORG_ALIAS` are set, the explicit access token wins.
 
 **Client credentials (auto-refreshing):**
 

--- a/scripts/smoke_test_sf_cli.sh
+++ b/scripts/smoke_test_sf_cli.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Smoke test: drive the d360 MCP server over stdio with SF_ORG_ALIAS auth and run a SQL query.
+#
+# Usage: SF_ORG_ALIAS=sftutor ./scripts/smoke_test_sf_cli.sh
+set -euo pipefail
+
+ALIAS="${SF_ORG_ALIAS:?SF_ORG_ALIAS must be set (and sf must be authenticated for that alias)}"
+JAR="${JAR:-target/data360-mcp-server-1.0.0.jar}"
+
+if [[ ! -f "$JAR" ]]; then
+  echo "Jar not found at $JAR. Build with: mvn -DskipTests package" >&2
+  exit 1
+fi
+
+# AuthModeResolver prefers DATA360_ACCESS_TOKEN over SF_ORG_ALIAS when both are set; unset any
+# leftover explicit token so the SF CLI path is actually exercised.
+unset DATA360_ACCESS_TOKEN DATA360_INSTANCE_URL
+
+# JSON-RPC messages: init, initialized notification, list tools, call execute(d360_query_sql).
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}'
+INITED='{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
+LIST='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+CALL='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute","arguments":{"toolName":"d360_query_sql","paramsJson":"{\"sql\":\"SELECT 1 AS one\"}"}}}'
+
+{
+  printf '%s\n' "$INIT"
+  printf '%s\n' "$INITED"
+  printf '%s\n' "$LIST"
+  printf '%s\n' "$CALL"
+  # Give the server a moment to respond before EOF closes stdin.
+  sleep 30
+} | SF_ORG_ALIAS="$ALIAS" \
+    java -jar "$JAR" 2> /tmp/d360-mcp.stderr

--- a/src/main/java/com/salesforce/data360/mcp/auth/AuthModeResolver.java
+++ b/src/main/java/com/salesforce/data360/mcp/auth/AuthModeResolver.java
@@ -22,6 +22,7 @@ public final class AuthModeResolver {
 
     public static final String ACCESS_TOKEN = "access_token";
     public static final String CLIENT_CREDENTIALS = "client_credentials";
+    public static final String SF_CLI = "sf_cli";
     public static final String NONE = "none";
 
     private AuthModeResolver() {
@@ -35,6 +36,9 @@ public final class AuthModeResolver {
             && isNotBlank(properties.getClientId())
             && isNotBlank(properties.getClientSecret())) {
             return CLIENT_CREDENTIALS;
+        }
+        if (isNotBlank(properties.getSfOrgAlias())) {
+            return SF_CLI;
         }
         return NONE;
     }

--- a/src/main/java/com/salesforce/data360/mcp/auth/AuthService.java
+++ b/src/main/java/com/salesforce/data360/mcp/auth/AuthService.java
@@ -113,6 +113,11 @@ public class AuthService {
                     properties.getClientSecret()
                 );
 
+            case AuthModeResolver.SF_CLI:
+                log.info("Initialized with sf_cli auth mode (org alias: {})",
+                    properties.getSfOrgAlias());
+                return new SfCliAuth(properties.getSfOrgAlias());
+
             case AuthModeResolver.ACCESS_TOKEN:
                 log.info("Initialized with access_token auth mode");
                 return null;

--- a/src/main/java/com/salesforce/data360/mcp/auth/SfCliAuth.java
+++ b/src/main/java/com/salesforce/data360/mcp/auth/SfCliAuth.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.data360.mcp.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.salesforce.data360.mcp.model.auth.OAuthTokenResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Authenticator that shells out to the Salesforce CLI (`sf org display --target-org <alias> --json`)
+ * to obtain an access token and instance URL. This reuses the interactive auth session the user
+ * already established via `sf org login web --alias <alias>`, avoiding any Connected App setup.
+ *
+ * <p>The token and instance URL are cached by {@link AuthService} via {@link TokenCache} using the
+ * TTL reported on the returned {@link OAuthTokenResponse} ({@link #CACHE_TTL_SECONDS}); this class
+ * itself is stateless.
+ */
+public class SfCliAuth implements OAuthAuthenticator {
+
+    static final long PROCESS_TIMEOUT_SECONDS = 120;
+    // SF CLI tokens don't expose their true TTL via `org display`; cache briefly so we revalidate
+    // often and let the CLI transparently refresh its own session when needed.
+    static final long CACHE_TTL_SECONDS = 300;
+
+    private final String orgAlias;
+    private final ProcessRunner processRunner;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SfCliAuth(String orgAlias) {
+        this(orgAlias, SfCliAuth::runSfCli);
+    }
+
+    SfCliAuth(String orgAlias, ProcessRunner processRunner) {
+        this.orgAlias = orgAlias;
+        this.processRunner = processRunner;
+    }
+
+    @Override
+    public OAuthTokenResponse authenticate() {
+        ProcessResult result = processRunner.run(List.of(
+            "sf", "org", "display", "--target-org", orgAlias, "--json"
+        ));
+
+        if (result.exitCode() != 0) {
+            throw new IllegalStateException(
+                "sf CLI failed (exit " + result.exitCode() + ") for org '" + orgAlias + "'. "
+                    + "Ensure you've authenticated via: sf org login web --alias " + orgAlias
+                    + "\nstderr: " + truncate(result.stderr(), 500)
+            );
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(result.stdout());
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "sf CLI returned invalid JSON: " + truncate(result.stdout(), 500), e);
+        }
+
+        JsonNode resultNode = root.path("result");
+        String accessToken = resultNode.path("accessToken").asText(null);
+        String instanceUrl = resultNode.path("instanceUrl").asText(null);
+
+        if (accessToken == null || accessToken.isBlank()
+            || instanceUrl == null || instanceUrl.isBlank()) {
+            throw new IllegalStateException(
+                "sf CLI response missing accessToken or instanceUrl for org '" + orgAlias + "'");
+        }
+
+        return new OAuthTokenResponse(
+            accessToken,
+            instanceUrl,
+            "Bearer",
+            null,
+            CACHE_TTL_SECONDS
+        );
+    }
+
+    private static ProcessResult runSfCli(List<String> command) {
+        Process process = null;
+        try {
+            process = new ProcessBuilder(command).redirectErrorStream(false).start();
+            // Drain stdout and stderr concurrently so the child can't block on a full pipe buffer
+            // while we are waiting on the other stream — a classic Process deadlock.
+            CompletableFuture<String> stdoutFuture = readStreamAsync(process.getInputStream());
+            CompletableFuture<String> stderrFuture = readStreamAsync(process.getErrorStream());
+
+            boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                throw new IllegalStateException(
+                    "sf CLI command timed out after " + PROCESS_TIMEOUT_SECONDS + " seconds");
+            }
+            return new ProcessResult(
+                process.exitValue(),
+                stdoutFuture.get(),
+                stderrFuture.get()
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to invoke sf CLI. Install from "
+                    + "https://developer.salesforce.com/tools/salesforcecli", e);
+        } catch (InterruptedException e) {
+            if (process != null) process.destroyForcibly();
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("sf CLI invocation interrupted", e);
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to read sf CLI output", e.getCause());
+        }
+    }
+
+    private static CompletableFuture<String> readStreamAsync(InputStream stream) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return new String(stream.readAllBytes());
+            } catch (IOException e) {
+                throw new java.io.UncheckedIOException(e);
+            }
+        });
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max);
+    }
+
+    @FunctionalInterface
+    interface ProcessRunner {
+        ProcessResult run(List<String> command);
+    }
+
+    record ProcessResult(int exitCode, String stdout, String stderr) {
+    }
+}

--- a/src/main/java/com/salesforce/data360/mcp/config/AppProperties.java
+++ b/src/main/java/com/salesforce/data360/mcp/config/AppProperties.java
@@ -29,6 +29,7 @@ public class AppProperties {
     private String clientId;
     private String clientSecret;
     private String authFlow;
+    private String sfOrgAlias;
     private String apiVersion = "66.0";
     private String searchStrategy = "keyword";
 
@@ -78,6 +79,14 @@ public class AppProperties {
 
     public void setAuthFlow(String authFlow) {
         this.authFlow = authFlow;
+    }
+
+    public String getSfOrgAlias() {
+        return sfOrgAlias;
+    }
+
+    public void setSfOrgAlias(String sfOrgAlias) {
+        this.sfOrgAlias = sfOrgAlias;
     }
 
     public String getApiVersion() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,4 +55,5 @@ data360:
   client-id: ${DATA360_CLIENT_ID:}
   client-secret: ${DATA360_CLIENT_SECRET:}
   auth-flow: ${DATA360_AUTH_FLOW:access_token}
+  sf-org-alias: ${DATA360_SF_ORG_ALIAS:${SF_ORG_ALIAS:}}
   search-strategy: ${DATA360_SEARCH_STRATEGY:keyword}

--- a/src/test/java/com/salesforce/data360/mcp/auth/AuthModeResolverTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/auth/AuthModeResolverTest.java
@@ -87,6 +87,35 @@ public class AuthModeResolverTest {
     }
 
     @Test
+    public void returnsSfCliWhenOnlyOrgAliasSet() {
+        properties.setSfOrgAlias("sftutor");
+
+        assertThat(AuthModeResolver.determineAuthMode(properties))
+            .isEqualTo(AuthModeResolver.SF_CLI);
+    }
+
+    @Test
+    public void accessTokenTakesPriorityOverSfCli() {
+        properties.setAccessToken("tok");
+        properties.setInstanceUrl("https://myorg.salesforce.com");
+        properties.setSfOrgAlias("sftutor");
+
+        assertThat(AuthModeResolver.determineAuthMode(properties))
+            .isEqualTo(AuthModeResolver.ACCESS_TOKEN);
+    }
+
+    @Test
+    public void clientCredentialsTakesPriorityOverSfCli() {
+        properties.setAuthFlow("client_credentials");
+        properties.setClientId("cid");
+        properties.setClientSecret("csec");
+        properties.setSfOrgAlias("sftutor");
+
+        assertThat(AuthModeResolver.determineAuthMode(properties))
+            .isEqualTo(AuthModeResolver.CLIENT_CREDENTIALS);
+    }
+
+    @Test
     public void treatsBlankStringsAsNotSet() {
         properties.setAccessToken("   ");
         properties.setInstanceUrl("https://myorg.salesforce.com");

--- a/src/test/java/com/salesforce/data360/mcp/auth/SfCliAuthTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/auth/SfCliAuthTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.data360.mcp.auth;
+
+import com.salesforce.data360.mcp.model.auth.OAuthTokenResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SfCliAuthTest {
+
+    private static final String OK_JSON = """
+        {"status":0,"result":{"accessToken":"00D_test_token","instanceUrl":"https://sftutor.my.salesforce.com","username":"me@example.com"}}
+        """;
+
+    @Test
+    void parsesAccessTokenAndInstanceUrlFromSfCliOutput() {
+        SfCliAuth auth = new SfCliAuth("sftutor",
+            cmd -> new SfCliAuth.ProcessResult(0, OK_JSON, ""));
+
+        OAuthTokenResponse response = auth.authenticate();
+
+        assertThat(response.accessToken()).isEqualTo("00D_test_token");
+        assertThat(response.instanceUrl()).isEqualTo("https://sftutor.my.salesforce.com");
+        assertThat(response.expiresIn()).isEqualTo(SfCliAuth.CACHE_TTL_SECONDS);
+    }
+
+    @Test
+    void invokesSfCliWithExpectedArguments() {
+        java.util.concurrent.atomic.AtomicReference<List<String>> captured =
+            new java.util.concurrent.atomic.AtomicReference<>();
+        SfCliAuth auth = new SfCliAuth("my-alias", cmd -> {
+            captured.set(cmd);
+            return new SfCliAuth.ProcessResult(0, OK_JSON, "");
+        });
+
+        auth.authenticate();
+
+        assertThat(captured.get())
+            .containsExactly("sf", "org", "display", "--target-org", "my-alias", "--json");
+    }
+
+    @Test
+    void throwsWhenCliExitsNonZero() {
+        SfCliAuth auth = new SfCliAuth("missing",
+            cmd -> new SfCliAuth.ProcessResult(1, "", "No org for alias"));
+
+        assertThatThrownBy(auth::authenticate)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("sf CLI failed")
+            .hasMessageContaining("missing")
+            .hasMessageContaining("No org for alias");
+    }
+
+    @Test
+    void throwsWhenOutputIsNotJson() {
+        SfCliAuth auth = new SfCliAuth("sftutor",
+            cmd -> new SfCliAuth.ProcessResult(0, "not-json", ""));
+
+        assertThatThrownBy(auth::authenticate)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("invalid JSON");
+    }
+
+    @Test
+    void throwsWhenRequiredFieldsMissing() {
+        SfCliAuth auth = new SfCliAuth("sftutor",
+            cmd -> new SfCliAuth.ProcessResult(0, "{\"status\":0,\"result\":{}}", ""));
+
+        assertThatThrownBy(auth::authenticate)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("missing accessToken or instanceUrl");
+    }
+}


### PR DESCRIPTION
## Summary

- **New `sf_cli` auth mode.** Point `SF_ORG_ALIAS` (or `DATA360_SF_ORG_ALIAS`) at an alias already authenticated via `sf org login web`. The server shells out to `sf org display --target-org <alias> --json` on demand, reports a 5-minute TTL so the existing `TokenCache` refreshes transparently, and drains stdout/stderr concurrently to avoid the classic `Process` pipe-fill deadlock. Resolver precedence stays explicit-over-implicit: `access_token` → `client_credentials` → `sf_cli`.

## Why this matters

The SF CLI auth path makes the server usable in seconds for anyone who already runs `sf` (the common case for Salesforce engineers trying the server locally) — no Connected App dance required.

## Scope

Narrowed to SF CLI auth only. The V3 `/ssot/query-sql*` path fix and the removal of V1/V2 query tools — originally bundled here — are handled by #5.

## Test plan

- [x] `mvn test` — 495/495 green, including three new precedence cases in `AuthModeResolverTest` and a new `SfCliAuthTest` (non-zero exit, bad JSON, missing fields, argv shape via a pluggable `ProcessRunner`).
- [x] Manual end-to-end smoke test via `scripts/smoke_test_sf_cli.sh` against a Data 360–enabled org (`SELECT 1 AS one`) — returns the expected row and metadata through the MCP stdio transport.