### PR TITLE
Include MCP client identity in Sforce-Call-Options header

### DIFF
--- a/src/main/java/com/salesforce/data360/mcp/client/ClientContext.java
+++ b/src/main/java/com/salesforce/data360/mcp/client/ClientContext.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.salesforce.data360.mcp.client;
+
+/**
+ * Thread-local holder for MCP client identity, set per tool invocation.
+ */
+public final class ClientContext {
+
+    private static final ThreadLocal<String> CLIENT_INFO = new ThreadLocal<>();
+
+    private ClientContext() {}
+
+    public static void set(String clientInfo) {
+        CLIENT_INFO.set(clientInfo);
+    }
+
+    public static String get() {
+        return CLIENT_INFO.get();
+    }
+
+    public static void clear() {
+        CLIENT_INFO.remove();
+    }
+}

--- a/src/main/java/com/salesforce/data360/mcp/client/Data360Client.java
+++ b/src/main/java/com/salesforce/data360/mcp/client/Data360Client.java
@@ -44,15 +44,26 @@ public class Data360Client {
     private final RestClient restClient;
     private final AuthService authService;
     private final String apiVersion;
+    private final String serverCallOptions;
 
-    public Data360Client(RestClient restClient, AuthService authService, String apiVersion) {
+    public Data360Client(RestClient restClient, AuthService authService, String apiVersion,
+                         String serverCallOptions) {
         this.restClient = restClient;
         this.authService = authService;
         this.apiVersion = apiVersion;
+        this.serverCallOptions = serverCallOptions;
     }
 
     private String baseUrl() {
         return authService.getInstanceUrl() + "/services/data/v" + apiVersion;
+    }
+
+    private String sforceCallOptions() {
+        String clientInfo = ClientContext.get();
+        if (clientInfo == null) {
+            return serverCallOptions;
+        }
+        return serverCallOptions + "/" + clientInfo;
     }
 
     public <T> T get(String path, Class<T> responseType) {
@@ -62,6 +73,7 @@ public class Data360Client {
             restClient.get()
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .retrieve()
                 .body(responseType)
         );
@@ -75,6 +87,7 @@ public class Data360Client {
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
                 .header("Content-Type", "application/json")
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .body(body)
                 .retrieve()
                 .body(responseType)
@@ -89,6 +102,7 @@ public class Data360Client {
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
                 .header("Content-Type", "application/json")
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .body(body)
                 .retrieve()
                 .body(responseType)
@@ -103,6 +117,7 @@ public class Data360Client {
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
                 .header("Content-Type", "application/json")
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .body(body)
                 .retrieve()
                 .body(responseType)
@@ -116,6 +131,7 @@ public class Data360Client {
             restClient.delete()
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .retrieve()
                 .toBodilessEntity();
             return null;
@@ -129,6 +145,7 @@ public class Data360Client {
             restClient.delete()
                 .uri(URI.create(fullUrl))
                 .header("Authorization", "Bearer " + authService.getAccessToken())
+                .header("Sforce-Call-Options", sforceCallOptions())
                 .retrieve()
                 .body(responseType)
         );

--- a/src/main/java/com/salesforce/data360/mcp/config/Data360RuntimeConfiguration.java
+++ b/src/main/java/com/salesforce/data360/mcp/config/Data360RuntimeConfiguration.java
@@ -17,6 +17,7 @@
 package com.salesforce.data360.mcp.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.salesforce.data360.mcp.client.ClientContext;
 import com.salesforce.data360.mcp.runtime.FamilyCatalog;
 import com.salesforce.data360.mcp.runtime.HybridSearchStrategy;
 import com.salesforce.data360.mcp.runtime.KeywordSearchStrategy;
@@ -84,6 +85,12 @@ public class Data360RuntimeConfiguration {
 
             specs.add(new McpServerFeatures.SyncToolSpecification(tool,
                 (exchange, request) -> {
+                    if (exchange != null) {
+                        McpSchema.Implementation clientInfo = exchange.getClientInfo();
+                        if (clientInfo != null) {
+                            ClientContext.set(clientInfo.name() + "/" + clientInfo.version());
+                        }
+                    }
                     try {
                         Object result = registry.invokeForResult(toolName, request.arguments());
                         String json = result == null ? "{}"
@@ -94,6 +101,8 @@ public class Data360RuntimeConfiguration {
                         String msg = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
                         return new McpSchema.CallToolResult(
                             List.of(new McpSchema.TextContent("Error: " + msg)), true, null, null);
+                    } finally {
+                        ClientContext.clear();
                     }
                 }));
         }

--- a/src/main/java/com/salesforce/data360/mcp/config/RestClientConfig.java
+++ b/src/main/java/com/salesforce/data360/mcp/config/RestClientConfig.java
@@ -36,17 +36,12 @@ public class RestClientConfig {
         AuthService authService,
         AppProperties properties
     ) {
+        String callOptions = "client=" + serverName + "/" + serverVersion;
         return new Data360Client(
-            restClientBuilder(serverName, serverVersion).build(),
+            RestClient.builder().build(),
             authService,
-            properties.getApiVersion()
+            properties.getApiVersion(),
+            callOptions
         );
-    }
-
-    static final String SFORCE_CALL_OPTIONS = "Sforce-Call-Options";
-
-    static RestClient.Builder restClientBuilder(String serverName, String serverVersion) {
-        return RestClient.builder()
-            .defaultHeader(SFORCE_CALL_OPTIONS, "client=" + serverName + "/" + serverVersion);
     }
 }

--- a/src/test/java/com/salesforce/data360/mcp/client/Data360ClientTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/client/Data360ClientTest.java
@@ -74,7 +74,8 @@ class Data360ClientTest {
         when(authService.getAccessToken()).thenReturn("test-access-token");
         when(authService.getInstanceUrl()).thenReturn("https://test.salesforce.com");
 
-        client = new Data360Client(restClient, authService, "66.0");
+        client = new Data360Client(restClient, authService, "66.0",
+            "client=data360-mcp-server-oss/1.0.0");
     }
 
     @Test
@@ -83,7 +84,7 @@ class Data360ClientTest {
         when(restClient.get()).thenReturn(requestHeadersUriSpec);
         when(requestHeadersUriSpec.uri(URI.create("https://test.salesforce.com/services/data/v66.0/dmos")))
             .thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.header("Authorization", "Bearer test-access-token"))
+        when(requestHeadersSpec.header(anyString(), anyString()))
             .thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
 
@@ -155,7 +156,7 @@ class Data360ClientTest {
         when(restClient.delete()).thenReturn(requestHeadersUriSpec);
         when(requestHeadersUriSpec.uri(URI.create("https://test.salesforce.com/services/data/v66.0/dmos/123")))
             .thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.header("Authorization", "Bearer test-access-token"))
+        when(requestHeadersSpec.header(anyString(), anyString()))
             .thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.toBodilessEntity()).thenReturn(null);
@@ -169,7 +170,7 @@ class Data360ClientTest {
         when(restClient.get()).thenReturn(requestHeadersUriSpec);
         when(requestHeadersUriSpec.uri(URI.create("https://test.salesforce.com/services/data/v66.0/invalid")))
             .thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.header("Authorization", "Bearer test-access-token"))
+        when(requestHeadersSpec.header(anyString(), anyString()))
             .thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(String.class))
@@ -199,7 +200,7 @@ class Data360ClientTest {
         when(restClient.get()).thenReturn(requestHeadersUriSpec);
         when(requestHeadersUriSpec.uri(URI.create("https://test.salesforce.com/services/data/v66.0/error")))
             .thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.header("Authorization", "Bearer test-access-token"))
+        when(requestHeadersSpec.header(anyString(), anyString()))
             .thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(String.class))
@@ -227,7 +228,7 @@ class Data360ClientTest {
         when(restClient.get()).thenReturn(requestHeadersUriSpec);
         when(requestHeadersUriSpec.uri(URI.create("https://test.salesforce.com/services/data/v66.0/timeout")))
             .thenReturn(requestHeadersSpec);
-        when(requestHeadersSpec.header("Authorization", "Bearer test-access-token"))
+        when(requestHeadersSpec.header(anyString(), anyString()))
             .thenReturn(requestHeadersSpec);
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(String.class))

--- a/src/test/java/com/salesforce/data360/mcp/config/RestClientConfigTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/config/RestClientConfigTest.java
@@ -16,31 +16,68 @@
  */
 package com.salesforce.data360.mcp.config;
 
+import com.salesforce.data360.mcp.auth.AuthService;
+import com.salesforce.data360.mcp.client.ClientContext;
+import com.salesforce.data360.mcp.client.Data360Client;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 public class RestClientConfigTest {
 
-    @Test
-    public void restClientSendsSforceCallOptionsHeader() {
-        RestClient.Builder builder = RestClientConfig.restClientBuilder(
-            "data360-mcp-server-oss", "1.0.0"
-        );
-        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
-        RestClient client = builder.build();
+    @AfterEach
+    void tearDown() {
+        ClientContext.clear();
+    }
 
-        server.expect(requestTo("https://example.test/ping"))
-            .andExpect(header(RestClientConfig.SFORCE_CALL_OPTIONS, "client=data360-mcp-server-oss/1.0.0"))
+    @Test
+    public void requestIncludesServerCallOptions() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+
+        AuthService authService = mock(AuthService.class);
+        when(authService.getInstanceUrl()).thenReturn("https://example.test");
+        when(authService.getAccessToken()).thenReturn("token");
+
+        Data360Client client = new Data360Client(builder.build(), authService, "66.0",
+            "client=data360-mcp-server-oss/1.0.0");
+
+        server.expect(requestTo("https://example.test/services/data/v66.0/ssot/test"))
+            .andExpect(header("Sforce-Call-Options", "client=data360-mcp-server-oss/1.0.0"))
             .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
 
-        client.get().uri("https://example.test/ping").retrieve().toBodilessEntity();
+        client.get("/ssot/test", String.class);
+        server.verify();
+    }
 
+    @Test
+    public void requestIncludesMcpClientInfoWhenPresent() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+
+        AuthService authService = mock(AuthService.class);
+        when(authService.getInstanceUrl()).thenReturn("https://example.test");
+        when(authService.getAccessToken()).thenReturn("token");
+
+        Data360Client client = new Data360Client(builder.build(), authService, "66.0",
+            "client=data360-mcp-server-oss/1.0.0");
+
+        ClientContext.set("claude-code/1.0.31");
+
+        server.expect(requestTo("https://example.test/services/data/v66.0/ssot/test"))
+            .andExpect(header("Sforce-Call-Options",
+                "client=data360-mcp-server-oss/1.0.0/claude-code/1.0.31"))
+            .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+        client.get("/ssot/test", String.class);
         server.verify();
     }
 }


### PR DESCRIPTION
## Summary
- Captures MCP client identity (name/version) from the MCP exchange during tool invocations and appends it to the `Sforce-Call-Options` header as `client=data360-mcp-server-oss/1.0.0/<mcp-client>/<version>`
- Introduces `ClientContext` thread-local holder to pass client info from the MCP layer to the HTTP client without threading it through every method signature
- Adds null-safety for cases where MCP exchange or client info is unavailable

## Test plan
- [x] Unit tests verify `Sforce-Call-Options` header contains only server identity when no MCP client info is present
- [x] Unit tests verify header includes appended MCP client identity when `ClientContext` is set
- [x] `ClientContext` is cleared in `finally` block to prevent thread-local leaks