### PR TITLE
Add d360_segment_deactivate and fix d360_segment_delete path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `d360_segment_deactivate` tool — inverse of `d360_segment_publish`. Calls
+  `POST /ssot/segments/{segmentApiName}/actions/deactivate`.
+  ([#9](https://github.com/forcedotcom/d360-mcp-server/issues/9))
+
 ### Fixed
 
+- `d360_segment_delete` now uses the segment API name (developer name) in the
+  path; the underlying endpoint is `DELETE /ssot/segments/{segmentApiName}`.
+  ([#8](https://github.com/forcedotcom/d360-mcp-server/issues/8))
 - `d360_query_sql`, `d360_query_sql_status`, `d360_query_sql_rows`, and
   `d360_query_sql_cancel` now call `/services/data/vNN.0/ssot/query-sql*`
   instead of `/services/data/vNN.0/query-sql*`. The previous paths returned

--- a/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
+++ b/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
@@ -178,8 +178,9 @@ public class FamilyCatalog {
         t.add(new ToolDef("d360_segment_get", "Segment", "Get segment by ID. Check segmentStatus for ACTIVE.", "GET", "/ssot/segments/{id}"));
         t.add(new ToolDef("d360_segment_create", "Segment", "Create segment. Requires ACTIVE CIs first.", "POST", "/ssot/segments"));
         t.add(new ToolDef("d360_segment_update", "Segment", "Update segment metadata. Cannot change SQL via PATCH.", "PATCH", "/ssot/segments/{id}"));
-        t.add(new ToolDef("d360_segment_delete", "Segment", "Delete segment. Irreversible.", "DELETE", "/ssot/segments/{id}"));
+        t.add(new ToolDef("d360_segment_delete", "Segment", "Delete segment by API name (developer name). Irreversible.", "DELETE", "/ssot/segments/{apiName}"));
         t.add(new ToolDef("d360_segment_publish", "Segment", "Trigger segment calculation.", "POST", "/ssot/segments/{id}/actions/publish"));
+        t.add(new ToolDef("d360_segment_deactivate", "Segment", "Deactivate a segment by API name (developer name). Inverse of publish.", "POST", "/ssot/segments/{apiName}/actions/deactivate"));
 
         // ── CalculatedInsights ─────────────────────────────────────────────
         t.add(new ToolDef("d360_ci_list", "CalculatedInsights", "List all CIs. Check status for ACTIVE.", "GET", "/ssot/calculated-insights"));

--- a/src/main/java/com/salesforce/data360/mcp/tools/SegmentTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/SegmentTools.java
@@ -129,19 +129,20 @@ public class SegmentTools {
     }
 
     /**
-     * Delete a segment.
-     * This operation is irreversible and deactivates the segment.
+     * Delete a segment by API name.
+     * The path requires the segment API name (developer name), not the ID.
+     * Irreversible.
      */
     @McpTool(
         name = "d360_segment_delete",
-        description = "Delete a segment."
+        description = "Delete a segment by API name (developer name). Irreversible."
     )
     public String deleteSegment(
-        @McpToolParam(description = "The segment ID to delete") String segmentId,
+        @McpToolParam(description = "The segment API name (developer name)") String segmentApiName,
         @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
     ) {
         try {
-            String path = ToolUtils.buildPath("/ssot/segments/" + ToolUtils.encodePath(segmentId), dataspace);
+            String path = ToolUtils.buildPath("/ssot/segments/" + ToolUtils.encodePath(segmentApiName), dataspace);
             Map result = client.delete(path, Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {
@@ -163,6 +164,26 @@ public class SegmentTools {
     ) {
         try {
             String path = ToolUtils.buildPath("/ssot/segments/" + ToolUtils.encodePath(segmentId) + "/actions/publish", dataspace);
+            Map result = client.post(path, Map.of(), Map.class);
+            return JsonUtil.toJson(result);
+        } catch (ApiException e) {
+            return ToolUtils.errorResponse(e);
+        }
+    }
+
+    /**
+     * Deactivate a segment by API name. Inverse of publish.
+     */
+    @McpTool(
+        name = "d360_segment_deactivate",
+        description = "Deactivate a segment by API name (developer name). Inverse of publish."
+    )
+    public String deactivateSegment(
+        @McpToolParam(description = "The segment API name (developer name)") String segmentApiName,
+        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
+    ) {
+        try {
+            String path = ToolUtils.buildPath("/ssot/segments/" + ToolUtils.encodePath(segmentApiName) + "/actions/deactivate", dataspace);
             Map result = client.post(path, Map.of(), Map.class);
             return JsonUtil.toJson(result);
         } catch (ApiException e) {

--- a/src/test/java/com/salesforce/data360/mcp/tools/ReadOnlyIntegrationTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/ReadOnlyIntegrationTest.java
@@ -72,6 +72,8 @@ public class ReadOnlyIntegrationTest extends IntegrationTestBase {
         assertThrows(IllegalArgumentException.class,
                 () -> assertSafeTool("d360_segment_publish"));
         assertThrows(IllegalArgumentException.class,
+                () -> assertSafeTool("d360_segment_deactivate"));
+        assertThrows(IllegalArgumentException.class,
                 () -> assertSafeTool("d360_ci_enable"));
         assertThrows(IllegalArgumentException.class,
                 () -> assertSafeTool("d360_ci_run"));

--- a/src/test/java/com/salesforce/data360/mcp/tools/SegmentToolsTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/SegmentToolsTest.java
@@ -181,14 +181,14 @@ class SegmentToolsTest {
     @Test
     void testDeleteSegment_success() {
         // Given
-        String segmentId = "seg-123";
+        String segmentApiName = "High_Value_Customers__seg";
         Map<String, Object> mockResponse = Map.of("success", true);
 
         when(client.delete(anyString(), eq(Map.class)))
             .thenReturn(mockResponse);
 
         // When
-        String result = segmentTools.deleteSegment(segmentId, DEFAULT_DATASPACE);
+        String result = segmentTools.deleteSegment(segmentApiName, DEFAULT_DATASPACE);
 
         // Then
         assertThat(result).contains("success");
@@ -196,7 +196,31 @@ class SegmentToolsTest {
         ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         verify(client).delete(pathCaptor.capture(), eq(Map.class));
 
-        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/segments/seg-123?dataspace=default");
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/segments/High_Value_Customers__seg?dataspace=default");
+    }
+
+    @Test
+    void testDeactivateSegment_success() {
+        // Given
+        String segmentApiName = "High_Value_Customers__seg";
+        Map<String, Object> mockResponse = Map.of(
+            "id", "seg-123",
+            "segmentStatus", "INACTIVE"
+        );
+
+        when(client.post(anyString(), any(), eq(Map.class)))
+            .thenReturn(mockResponse);
+
+        // When
+        String result = segmentTools.deactivateSegment(segmentApiName, DEFAULT_DATASPACE);
+
+        // Then
+        assertThat(result).contains("INACTIVE");
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
+
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/segments/High_Value_Customers__seg/actions/deactivate?dataspace=default");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `d360_segment_deactivate` as the inverse of `d360_segment_publish`. Calls `POST /ssot/segments/{segmentApiName}/actions/deactivate`. Closes #9.
- Fix `d360_segment_delete` to use the segment API name (developer name) in the path instead of the segment ID; the underlying endpoint is `DELETE /ssot/segments/{segmentApiName}`. Closes #8.

## Test plan

- [x] `mvn test` — 481 tests pass
- [x] `SegmentToolsTest.testDeleteSegment_success` updated to verify the API name is used in the path
- [x] New `SegmentToolsTest.testDeactivateSegment_success` covers the deactivate happy path
- [x] `ReadOnlyIntegrationTest` asserts `d360_segment_deactivate` is rejected by the read-only safety guard
- [ ] Manual smoke test against a live org — delete and deactivate a segment by API name