### PR TITLE
Add connection schema discovery tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Connection schema discovery tools: `d360_connection_db_schemas_list`,
+  `d360_connection_objects_list`, and `d360_connection_object_fields_describe`
+  for browsing databases, schemas, tables, and field-level metadata of a
+  connection (e.g., Snowflake).
+
 ### Fixed
 
 - `d360_query_sql`, `d360_query_sql_status`, `d360_query_sql_rows`, and

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Under the hood, 187 operations are organized into 21 tool families:
 | Calculated Insights | 10 | CI CRUD, run, validate, query |
 | Segment | 6 | Segment CRUD + publish |
 | Dataspace | 8 | Dataspace + member management |
-| Connection | 11 | Connector metadata, connection CRUD, Snowflake connections |
+| Connection | 14 | Connector metadata, connection CRUD, Snowflake connections, schema/object/field discovery |
 | Query | 16 | SQL, profile, datagraph, and metadata queries |
 | Activation | 10 | Activation + target CRUD |
 | SDM | 38 | Semantic Data Models — dimensions, measures, relationships, queries |

--- a/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
+++ b/src/main/java/com/salesforce/data360/mcp/runtime/FamilyCatalog.java
@@ -172,6 +172,9 @@ public class FamilyCatalog {
         t.add(new ToolDef("d360_connection_endpoints", "Connection", "List pre-configured endpoints.", "GET", "/ssot/connection-endpoints"));
         t.add(new ToolDef("d360_snowflake_connection_list", "Connection", "List Data 360 connections for a connector type. Use connectorType=SNOWFLAKE for Snowflake.", "GET", "/connections"));
         t.add(new ToolDef("d360_connection_create_snowflake", "Connection", "Create a Snowflake connection with KeyPair auth. Provide private key content directly.", "POST", "/connections"));
+        t.add(new ToolDef("d360_connection_db_schemas_list", "Connection", "List database schemas available in a connection (e.g., Snowflake schemas). Pass database name in advancedAttributes.", "POST", "/ssot/connections/{id}/database-schemas"));
+        t.add(new ToolDef("d360_connection_objects_list", "Connection", "List objects/tables available in a connection. Use database/schema in advancedAttributes for DB connections.", "POST", "/ssot/connections/{id}/objects"));
+        t.add(new ToolDef("d360_connection_object_fields_describe", "Connection", "Describe field-level schema (names, types, primary keys) of an object in a connection.", "POST", "/ssot/connections/{id}/objects/{resourceName}/fields"));
 
         // ── Segment ────────────────────────────────────────────────────────
         t.add(new ToolDef("d360_segment_list", "Segment", "List all segments.", "GET", "/ssot/segments"));

--- a/src/main/java/com/salesforce/data360/mcp/tools/MetadataTools.java
+++ b/src/main/java/com/salesforce/data360/mcp/tools/MetadataTools.java
@@ -366,4 +366,107 @@ public class MetadataTools {
         }
     }
 
+    // ============================================================
+    // Connection Schema Discovery
+    // ============================================================
+
+    @McpTool(
+        name = "d360_connection_db_schemas_list",
+        description = "List database schemas available in a connection (e.g., Snowflake schemas). "
+            + "Pass database name and other connector-specific properties via advancedAttributes (e.g., {\"database\":\"MY_DB\"})."
+    )
+    public String listConnectionDbSchemas(
+        @McpToolParam(description = "The connection ID") String connectionId,
+        @McpToolParam(description = "JSON object of connector-specific properties (e.g., {\"database\":\"MY_DB\"})") String advancedAttributes,
+        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
+    ) {
+        try {
+            Map<String, Object> attrs = ToolUtils.parseJson(advancedAttributes, Map.class, "advancedAttributes");
+            Map<String, Object> body = new HashMap<>();
+            body.put("advancedAttributes", attrs);
+
+            Map<String, Object> params = new HashMap<>();
+            if (dataspace != null) params.put("dataspace", dataspace);
+
+            String path = ToolUtils.buildPath(
+                "/ssot/connections/" + ToolUtils.encodePath(connectionId) + "/database-schemas",
+                params
+            );
+            Map result = client.post(path, body, Map.class);
+            return JsonUtil.toJson(result);
+        } catch (IllegalArgumentException | ApiException e) {
+            return ToolUtils.errorResponse(e);
+        }
+    }
+
+    @McpTool(
+        name = "d360_connection_objects_list",
+        description = "List objects/tables available in a connection. For DB connections, pass database and schema "
+            + "via advancedAttributes (e.g., {\"database\":\"MY_DB\",\"schema\":\"PUBLIC\"})."
+    )
+    public String listConnectionObjects(
+        @McpToolParam(description = "The connection ID") String connectionId,
+        @McpToolParam(description = "JSON object of connector-specific properties (e.g., {\"database\":\"MY_DB\",\"schema\":\"PUBLIC\"})", required = false) String advancedAttributes,
+        @McpToolParam(description = "JSON object of filter criteria for narrowing the result set", required = false) String filters,
+        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
+    ) {
+        try {
+            Map<String, Object> body = new HashMap<>();
+            if (advancedAttributes != null && !advancedAttributes.isEmpty()) {
+                body.put("advancedAttributes", ToolUtils.parseJson(advancedAttributes, Map.class, "advancedAttributes"));
+            }
+            if (filters != null && !filters.isEmpty()) {
+                body.put("filters", ToolUtils.parseJson(filters, Map.class, "filters"));
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            if (dataspace != null) params.put("dataspace", dataspace);
+
+            String path = ToolUtils.buildPath(
+                "/ssot/connections/" + ToolUtils.encodePath(connectionId) + "/objects",
+                params
+            );
+            Map result = client.post(path, body, Map.class);
+            return JsonUtil.toJson(result);
+        } catch (IllegalArgumentException | ApiException e) {
+            return ToolUtils.errorResponse(e);
+        }
+    }
+
+    @McpTool(
+        name = "d360_connection_object_fields_describe",
+        description = "Describe field-level schema (names, types, primary keys) of an object in a connection. "
+            + "Use d360_connection_objects_list first to discover the resourceName."
+    )
+    public String describeConnectionObjectFields(
+        @McpToolParam(description = "The connection ID") String connectionId,
+        @McpToolParam(description = "The object/table name (from d360_connection_objects_list)") String resourceName,
+        @McpToolParam(description = "JSON object of connector-specific properties (e.g., {\"database\":\"MY_DB\",\"schema\":\"PUBLIC\"})", required = false) String advancedAttributes,
+        @McpToolParam(description = "JSON object of filter criteria for narrowing the field set", required = false) String filters,
+        @McpToolParam(description = "Optional dataspace name", required = false) String dataspace
+    ) {
+        try {
+            Map<String, Object> body = new HashMap<>();
+            if (advancedAttributes != null && !advancedAttributes.isEmpty()) {
+                body.put("advancedAttributes", ToolUtils.parseJson(advancedAttributes, Map.class, "advancedAttributes"));
+            }
+            if (filters != null && !filters.isEmpty()) {
+                body.put("filters", ToolUtils.parseJson(filters, Map.class, "filters"));
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            if (dataspace != null) params.put("dataspace", dataspace);
+
+            String path = ToolUtils.buildPath(
+                "/ssot/connections/" + ToolUtils.encodePath(connectionId)
+                    + "/objects/" + ToolUtils.encodePath(resourceName) + "/fields",
+                params
+            );
+            Map result = client.post(path, body, Map.class);
+            return JsonUtil.toJson(result);
+        } catch (IllegalArgumentException | ApiException e) {
+            return ToolUtils.errorResponse(e);
+        }
+    }
+
 }

--- a/src/main/resources/metadata/payload-examples.json
+++ b/src/main/resources/metadata/payload-examples.json
@@ -1131,5 +1131,21 @@
         "type": "SDM"
       }
     ]
+  },
+  "d360_connection_db_schemas_list": {
+    "connectionId": "9cgaj0000012O5hAAE",
+    "advancedAttributes": "{\"database\":\"SNOWFLAKE_SAMPLE_DATA\"}",
+    "_note": "advancedAttributes is a JSON string; for Snowflake pass the database name. Returns schemas under that database. Use d360_snowflake_connection_list (or d360_connection_list) to find the connectionId."
+  },
+  "d360_connection_objects_list": {
+    "connectionId": "9cgaj0000012O5hAAE",
+    "advancedAttributes": "{\"database\":\"SNOWFLAKE_SAMPLE_DATA\",\"schema\":\"TPCH_SF1\"}",
+    "_note": "Lists tables/objects in a connection. For DB connectors (e.g., Snowflake) scope by database+schema in advancedAttributes — omitting them can return very large result sets. Omit advancedAttributes for non-DB connectors (e.g., Salesforce)."
+  },
+  "d360_connection_object_fields_describe": {
+    "connectionId": "9cgaj0000012O5hAAE",
+    "resourceName": "CUSTOMER",
+    "advancedAttributes": "{\"database\":\"SNOWFLAKE_SAMPLE_DATA\",\"schema\":\"TPCH_SF1\"}",
+    "_note": "Describes column-level schema (names, types, primary keys) of a single object. Discover resourceName via d360_connection_objects_list first."
   }
 }

--- a/src/test/java/com/salesforce/data360/mcp/tools/MetadataToolsTest.java
+++ b/src/test/java/com/salesforce/data360/mcp/tools/MetadataToolsTest.java
@@ -365,4 +365,132 @@ class MetadataToolsTest {
 
         assertThat(result).contains("error", "500");
     }
+
+    // ============================================================
+    // Connection Schema Discovery Tests
+    // ============================================================
+
+    @Test
+    void testListConnectionDbSchemas_buildsCorrectPathAndBody() {
+        Map<String, Object> mockResponse = Map.of("databaseSchemas", List.of("PUBLIC", "ANALYTICS"));
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        String result = metadataTools.listConnectionDbSchemas(
+            "CONN_ID",
+            "{\"database\":\"MY_DB\"}",
+            null
+        );
+
+        assertThat(result).contains("PUBLIC", "ANALYTICS");
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
+
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/connections/CONN_ID/database-schemas");
+        Map<String, Object> body = bodyCaptor.getValue();
+        assertThat(body).containsOnlyKeys("advancedAttributes");
+        assertThat((Map) body.get("advancedAttributes")).containsEntry("database", "MY_DB");
+    }
+
+    @Test
+    void testListConnectionDbSchemas_withDataspace() {
+        Map<String, Object> mockResponse = Map.of("databaseSchemas", List.of());
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        metadataTools.listConnectionDbSchemas("CONN_ID", "{\"database\":\"DB\"}", DEFAULT_DATASPACE);
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client).post(pathCaptor.capture(), any(), eq(Map.class));
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/connections/CONN_ID/database-schemas?dataspace=default");
+    }
+
+    @Test
+    void testListConnectionDbSchemas_invalidJsonReturnsError() {
+        String result = metadataTools.listConnectionDbSchemas("CONN_ID", "not json", null);
+
+        assertThat(result).contains("error", "Invalid JSON advancedAttributes");
+    }
+
+    @Test
+    void testListConnectionObjects_omitsUnsetKeys() {
+        Map<String, Object> mockResponse = Map.of(
+            "objects", List.of(Map.of("name", "ORDERS", "label", "Orders"))
+        );
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        String result = metadataTools.listConnectionObjects(
+            "CONN_ID",
+            "{\"database\":\"MY_DB\",\"schema\":\"PUBLIC\"}",
+            null,
+            null
+        );
+
+        assertThat(result).contains("ORDERS");
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
+
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/connections/CONN_ID/objects");
+        Map<String, Object> body = bodyCaptor.getValue();
+        assertThat(body).containsOnlyKeys("advancedAttributes");
+        assertThat((Map) body.get("advancedAttributes")).containsEntry("schema", "PUBLIC");
+    }
+
+    @Test
+    void testListConnectionObjects_withFilters() {
+        Map<String, Object> mockResponse = Map.of("objects", List.of());
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        metadataTools.listConnectionObjects(
+            "CONN_ID",
+            "{\"database\":\"DB\"}",
+            "{\"namePrefix\":\"ORD\"}",
+            null
+        );
+
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(client).post(anyString(), bodyCaptor.capture(), eq(Map.class));
+
+        Map<String, Object> body = bodyCaptor.getValue();
+        assertThat(body).containsKeys("advancedAttributes", "filters");
+        assertThat((Map) body.get("filters")).containsEntry("namePrefix", "ORD");
+    }
+
+    @Test
+    void testDescribeConnectionObjectFields_encodesResourceName() {
+        Map<String, Object> mockResponse = Map.of(
+            "fields", List.of(Map.of("name", "ID", "type", "Number")),
+            "primaryKeys", List.of("ID")
+        );
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        String result = metadataTools.describeConnectionObjectFields(
+            "CONN_ID",
+            "MY.TABLE",
+            "{\"database\":\"DB\",\"schema\":\"PUBLIC\"}",
+            "{\"includeSystem\":false}",
+            null
+        );
+
+        assertThat(result).contains("primaryKeys", "ID");
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(client).post(pathCaptor.capture(), bodyCaptor.capture(), eq(Map.class));
+
+        assertThat(pathCaptor.getValue()).isEqualTo("/ssot/connections/CONN_ID/objects/MY.TABLE/fields");
+        Map<String, Object> body = bodyCaptor.getValue();
+        assertThat(body).containsKeys("advancedAttributes", "filters");
+    }
+
+    @Test
+    void testDescribeConnectionObjectFields_minimalParams() {
+        Map<String, Object> mockResponse = Map.of("fields", List.of());
+        when(client.post(anyString(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        metadataTools.describeConnectionObjectFields("CONN_ID", "ORDERS", null, null, null);
+
+        ArgumentCaptor<Map> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(client).post(anyString(), bodyCaptor.capture(), eq(Map.class));
+        assertThat(bodyCaptor.getValue()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

Adds three tools for introspecting external connections, useful as discovery steps before creating data streams or mappings:

- `d360_connection_db_schemas_list` — list database schemas (e.g., Snowflake schemas under a database)
- `d360_connection_objects_list` — list tables/objects in a connection, optionally scoped by database/schema for DB connectors
- `d360_connection_object_fields_describe` — describe field-level schema (names, types, primary keys) for an object in a connection

The agent can now browse what databases, schemas, tables, and fields are available in a connection without leaving the MCP session.

## Test plan

- [x] `mvn test` — 487 tests pass
- [x] Unit tests in `MetadataToolsTest` cover path construction, body shape, dataspace handling, filter passthrough, resourceName encoding, and invalid-JSON error responses
- [x] `payload-examples.json` updated with example payloads for each new tool
- [x] README family count updated (Connection: 11 → 14)
- [ ] Manual smoke test against a Snowflake connection — list schemas, list tables, describe fields